### PR TITLE
Refactor Target Report Card Apps

### DIFF
--- a/glados/static/coffee/URLProcessor.coffee
+++ b/glados/static/coffee/URLProcessor.coffee
@@ -9,7 +9,7 @@ class URLProcessor
     return pathnameParts[pathnameParts.length - 2]
 
   # this gets the chembl_id from the url in the page
-  # it expects the url to be .*\/CHEMBL1151960\/$
+  # it expects the url to be .*\/CHEMBL1151960\/embed\/.*\/$
   @getRequestedChemblIDWhenEmbedded = ->
 
     pathname = window.location.pathname;

--- a/glados/static/coffee/targetReportCardApp.coffee
+++ b/glados/static/coffee/targetReportCardApp.coffee
@@ -1,96 +1,92 @@
 class TargetReportCardApp
 
   # -------------------------------------------------------------
-  # Models
+  # Initialisation
   # -------------------------------------------------------------
-  @initTarget = (chembl_id) ->
+  @init = ->
+    $('.scrollspy').scrollSpy()
+    ScrollSpyHelper.initializeScrollSpyPinner()
+
+    GlobalVariables.CHEMBL_ID = URLProcessor.getRequestedChemblID()
+
     target = new Target
-      target_chembl_id: chembl_id
+      target_chembl_id: GlobalVariables.CHEMBL_ID
 
-    return target
+    appDrugsClinCandsList = new ApprovedDrugClinicalCandidateList
+    appDrugsClinCandsList.url = Settings.WS_BASE_URL + 'mechanism.json?target_chembl_id=' + (GlobalVariables.CHEMBL_ID)
+    +'&order_by=molecule_chembl_id&limit=1000'
 
-  @initAppDrugClinCands = (chembl_id) ->
-    appDrugCCList = new ApprovedDrugClinicalCandidateList
+    targetRelations = new TargetRelationList
+    targetRelations.url = Settings.WS_DEV_BASE_URL + 'target_relation.json?related_target_chembl_id=' + GlobalVariables.CHEMBL_ID + '&order_by=target_chembl_id&limit=1000'
 
-    appDrugCCList.url = Settings.WS_BASE_URL + 'mechanism.json?target_chembl_id=' + (chembl_id) + '&order_by=molecule_chembl_id&limit=1000'
-    return appDrugCCList
+    new TargetNameAndClassificationView
+      model: target
+      el: $('#TNameClassificationCard')
 
-  @initAppDrugClinCandsTest = (chembl_id) ->
-    appDrugCCList = new ApprovedDrugClinicalCandidateListTest
+    new TargetComponentsView
+      model: target
+      el: $('#TComponentsCard')
 
-    appDrugCCList.url = Settings.WS_BASE_URL + 'mechanism.json?target_chembl_id=' + (chembl_id) + '&order_by=molecule_chembl_id&limit=1000'
-    return appDrugCCList
+    new RelationsView
+      collection: targetRelations
+      el: $('#TRelationsCard')
 
-  @initTargetRelations = (chembl_id) ->
+    new ApprovedDrugsClinicalCandidatesView
+      collection: appDrugsClinCandsList
+      el: $('#ApprovedDrugsAndClinicalCandidatesCard')
 
-    targRelList = new TargetRelationList
+    target.fetch()
+    appDrugsClinCandsList.fetch()
+    targetRelations.fetch({reset: true})
 
-    targRelList.url = Settings.WS_DEV_BASE_URL + 'target_relation.json?related_target_chembl_id=' + chembl_id + '&order_by=target_chembl_id&limit=1000'
-    return targRelList
+  @initTargetNameAndClassification = ->
 
-  # -------------------------------------------------------------
-  # Views
-  # -------------------------------------------------------------
+    GlobalVariables.CHEMBL_ID = URLProcessor.getRequestedChemblIDWhenEmbedded()
 
-  ### *
-    * Initializes the TNCView (Target Name and Clasification View)
-    * @param {Compound} model, base model for the view
-    * @param {JQuery} top_level_elem element that renders the model.
-    * @return {TargetNameClassificationView} the view that has been created
-  ###
-  @initTNCView = (model, top_level_elem) ->
-    tncView = new TargetNameAndClassificationView
-      model: model
-      el: top_level_elem
+    target = new Target
+      target_chembl_id: GlobalVariables.CHEMBL_ID
 
-    return tncView
+    new TargetNameAndClassificationView
+      model: target
+      el: $('#TNameClassificationCard')
+    target.fetch()
 
+  @initTargetComponents = ->
 
-  ### *
-    * Initializes the TComponentsView (Target Components View)
-    * @param {Target} model, base model for the view
-    * @param {JQuery} top_level_elem element that renders the model.
-    * @return {TargetComponentsView} the view that has been created
-  ###
-  @initTComponentsView = (model, top_level_elem) ->
-    tcView = new TargetComponentsView
-      model: model
-      el: top_level_elem
+    GlobalVariables.CHEMBL_ID = URLProcessor.getRequestedChemblIDWhenEmbedded()
 
-    return tcView
+    target = new Target
+      target_chembl_id: GlobalVariables.CHEMBL_ID
 
+    new TargetComponentsView
+      model: target
+      el: $('#TComponentsCard')
 
-  ### *
-    * Initializes the ADCC View (Approved Drugs Clinical Candidates View)
-    * @param {Collection} adccList, the collection of approved drugs and clinical candidates
-    * @param {JQuery} top_level_elem element that renders the model.
-    * @return {TargetComponentsView} the view that has been created
-  ###
-  @initADCC = (adccList, top_level_elem) ->
-    adccView = new ApprovedDrugsClinicalCandidatesView
-      collection: adccList
-      el: top_level_elem
+    target.fetch()
 
-    return adccView
+  @initTargetRelations = ->
 
+    GlobalVariables.CHEMBL_ID = URLProcessor.getRequestedChemblIDWhenEmbedded()
 
-  @initADCCTest = (adccList, top_level_elem) ->
-    adccView = new ApprovedDrugsClinicalCandidatesViewTest
-      collection: adccList
-      el: top_level_elem
+    targetRelations = new TargetRelationList
+    targetRelations.url = Settings.WS_DEV_BASE_URL + 'target_relation.json?related_target_chembl_id=' + GlobalVariables.CHEMBL_ID + '&order_by=target_chembl_id&limit=1000'
 
-    return adccView
+    new RelationsView
+      collection: targetRelations
+      el: $('#TRelationsCard')
 
-  ### *
-    * Initializes the TRelationsView (Target Relations View)
-    * @param {Compound} rel_list, the collection of the relations of the target
-    * @param {JQuery} top_level_elem element that renders the model.
-    * @return {TargetComponentsView} the view that has been created
-  ###
-  @initTRelationsView = (rel_list, top_level_elem) ->
+    targetRelations.fetch({reset: true})
 
-    trelView = new RelationsView
-      collection: rel_list
-      el: top_level_elem
+  @initApprovedDrugsClinicalCandidates = ->
 
-    return trelView
+    GlobalVariables.CHEMBL_ID = URLProcessor.getRequestedChemblIDWhenEmbedded()
+
+    appDrugsClinCandsList = new ApprovedDrugClinicalCandidateList
+    appDrugsClinCandsList.url = Settings.WS_BASE_URL + 'mechanism.json?target_chembl_id=' + GlobalVariables.CHEMBL_ID + '&order_by=molecule_chembl_id&limit=1000'
+
+    new ApprovedDrugsClinicalCandidatesView
+      collection: appDrugsClinCandsList
+      el: $('#ApprovedDrugsAndClinicalCandidatesCard')
+
+    appDrugsClinCandsList.fetch()
+

--- a/glados/static/js/targetReportCardApp.js
+++ b/glados/static/js/targetReportCardApp.js
@@ -5,110 +5,92 @@ TargetReportCardApp = (function() {
 
   function TargetReportCardApp() {}
 
-  TargetReportCardApp.initTarget = function(chembl_id) {
-    var target;
+  TargetReportCardApp.init = function() {
+    var appDrugsClinCandsList, target, targetRelations;
+    $('.scrollspy').scrollSpy();
+    ScrollSpyHelper.initializeScrollSpyPinner();
+    GlobalVariables.CHEMBL_ID = URLProcessor.getRequestedChemblID();
     target = new Target({
-      target_chembl_id: chembl_id
+      target_chembl_id: GlobalVariables.CHEMBL_ID
     });
-    return target;
-  };
-
-  TargetReportCardApp.initAppDrugClinCands = function(chembl_id) {
-    var appDrugCCList;
-    appDrugCCList = new ApprovedDrugClinicalCandidateList;
-    appDrugCCList.url = Settings.WS_BASE_URL + 'mechanism.json?target_chembl_id=' + chembl_id + '&order_by=molecule_chembl_id&limit=1000';
-    return appDrugCCList;
-  };
-
-  TargetReportCardApp.initAppDrugClinCandsTest = function(chembl_id) {
-    var appDrugCCList;
-    appDrugCCList = new ApprovedDrugClinicalCandidateListTest;
-    appDrugCCList.url = Settings.WS_BASE_URL + 'mechanism.json?target_chembl_id=' + chembl_id + '&order_by=molecule_chembl_id&limit=1000';
-    return appDrugCCList;
-  };
-
-  TargetReportCardApp.initTargetRelations = function(chembl_id) {
-    var targRelList;
-    targRelList = new TargetRelationList;
-    targRelList.url = Settings.WS_DEV_BASE_URL + 'target_relation.json?related_target_chembl_id=' + chembl_id + '&order_by=target_chembl_id&limit=1000';
-    return targRelList;
-  };
-
-  /* *
-    * Initializes the TNCView (Target Name and Clasification View)
-    * @param {Compound} model, base model for the view
-    * @param {JQuery} top_level_elem element that renders the model.
-    * @return {TargetNameClassificationView} the view that has been created
-  */
-
-
-  TargetReportCardApp.initTNCView = function(model, top_level_elem) {
-    var tncView;
-    tncView = new TargetNameAndClassificationView({
-      model: model,
-      el: top_level_elem
+    appDrugsClinCandsList = new ApprovedDrugClinicalCandidateList;
+    appDrugsClinCandsList.url = Settings.WS_BASE_URL + 'mechanism.json?target_chembl_id=' + GlobalVariables.CHEMBL_ID;
+    +'&order_by=molecule_chembl_id&limit=1000';
+    targetRelations = new TargetRelationList;
+    targetRelations.url = Settings.WS_DEV_BASE_URL + 'target_relation.json?related_target_chembl_id=' + GlobalVariables.CHEMBL_ID + '&order_by=target_chembl_id&limit=1000';
+    new TargetNameAndClassificationView({
+      model: target,
+      el: $('#TNameClassificationCard')
     });
-    return tncView;
+    new TargetComponentsView({
+      model: target,
+      el: $('#TComponentsCard')
+    });
+    new RelationsView({
+      collection: targetRelations,
+      el: $('#TRelationsCard')
+    });
+    new ApprovedDrugsClinicalCandidatesView({
+      collection: appDrugsClinCandsList,
+      el: $('#ApprovedDrugsAndClinicalCandidatesCard')
+    });
+    target.fetch();
+    appDrugsClinCandsList.fetch();
+    return targetRelations.fetch({
+      reset: true
+    });
   };
 
-  /* *
-    * Initializes the TComponentsView (Target Components View)
-    * @param {Target} model, base model for the view
-    * @param {JQuery} top_level_elem element that renders the model.
-    * @return {TargetComponentsView} the view that has been created
-  */
-
-
-  TargetReportCardApp.initTComponentsView = function(model, top_level_elem) {
-    var tcView;
-    tcView = new TargetComponentsView({
-      model: model,
-      el: top_level_elem
+  TargetReportCardApp.initTargetNameAndClassification = function() {
+    var target;
+    GlobalVariables.CHEMBL_ID = URLProcessor.getRequestedChemblIDWhenEmbedded();
+    target = new Target({
+      target_chembl_id: GlobalVariables.CHEMBL_ID
     });
-    return tcView;
+    new TargetNameAndClassificationView({
+      model: target,
+      el: $('#TNameClassificationCard')
+    });
+    return target.fetch();
   };
 
-  /* *
-    * Initializes the ADCC View (Approved Drugs Clinical Candidates View)
-    * @param {Collection} adccList, the collection of approved drugs and clinical candidates
-    * @param {JQuery} top_level_elem element that renders the model.
-    * @return {TargetComponentsView} the view that has been created
-  */
-
-
-  TargetReportCardApp.initADCC = function(adccList, top_level_elem) {
-    var adccView;
-    adccView = new ApprovedDrugsClinicalCandidatesView({
-      collection: adccList,
-      el: top_level_elem
+  TargetReportCardApp.initTargetComponents = function() {
+    var target;
+    GlobalVariables.CHEMBL_ID = URLProcessor.getRequestedChemblIDWhenEmbedded();
+    target = new Target({
+      target_chembl_id: GlobalVariables.CHEMBL_ID
     });
-    return adccView;
+    new TargetComponentsView({
+      model: target,
+      el: $('#TComponentsCard')
+    });
+    return target.fetch();
   };
 
-  TargetReportCardApp.initADCCTest = function(adccList, top_level_elem) {
-    var adccView;
-    adccView = new ApprovedDrugsClinicalCandidatesViewTest({
-      collection: adccList,
-      el: top_level_elem
+  TargetReportCardApp.initTargetRelations = function() {
+    var targetRelations;
+    GlobalVariables.CHEMBL_ID = URLProcessor.getRequestedChemblIDWhenEmbedded();
+    targetRelations = new TargetRelationList;
+    targetRelations.url = Settings.WS_DEV_BASE_URL + 'target_relation.json?related_target_chembl_id=' + GlobalVariables.CHEMBL_ID + '&order_by=target_chembl_id&limit=1000';
+    new RelationsView({
+      collection: targetRelations,
+      el: $('#TRelationsCard')
     });
-    return adccView;
+    return targetRelations.fetch({
+      reset: true
+    });
   };
 
-  /* *
-    * Initializes the TRelationsView (Target Relations View)
-    * @param {Compound} rel_list, the collection of the relations of the target
-    * @param {JQuery} top_level_elem element that renders the model.
-    * @return {TargetComponentsView} the view that has been created
-  */
-
-
-  TargetReportCardApp.initTRelationsView = function(rel_list, top_level_elem) {
-    var trelView;
-    trelView = new RelationsView({
-      collection: rel_list,
-      el: top_level_elem
+  TargetReportCardApp.initApprovedDrugsClinicalCandidates = function() {
+    var appDrugsClinCandsList;
+    GlobalVariables.CHEMBL_ID = URLProcessor.getRequestedChemblIDWhenEmbedded();
+    appDrugsClinCandsList = new ApprovedDrugClinicalCandidateList;
+    appDrugsClinCandsList.url = Settings.WS_BASE_URL + 'mechanism.json?target_chembl_id=' + GlobalVariables.CHEMBL_ID + '&order_by=molecule_chembl_id&limit=1000';
+    new ApprovedDrugsClinicalCandidatesView({
+      collection: appDrugsClinCandsList,
+      el: $('#ApprovedDrugsAndClinicalCandidatesCard')
     });
-    return trelView;
+    return appDrugsClinCandsList.fetch();
   };
 
   return TargetReportCardApp;

--- a/glados/templates/glados/TargetReportCardParts/ApprovedDrugsAndClinicalCandidatesToEmbed.html
+++ b/glados/templates/glados/TargetReportCardParts/ApprovedDrugsAndClinicalCandidatesToEmbed.html
@@ -15,8 +15,6 @@
 
 {% block custom_js_inline %}
 
-var appDrugsClinCandsList = TargetReportCardApp.initAppDrugClinCands(CHEMBL_ID);
-var adccView = TargetReportCardApp.initADCC(appDrugsClinCandsList, $('#ApprovedDrugsAndClinicalCandidatesCard'));
-appDrugsClinCandsList.fetch();
+TargetReportCardApp.initApprovedDrugsClinicalCandidates();
 
 {% endblock %}

--- a/glados/templates/glados/TargetReportCardParts/ComponentsToEmbed.html
+++ b/glados/templates/glados/TargetReportCardParts/ComponentsToEmbed.html
@@ -13,8 +13,6 @@
 
 {% block custom_js_inline %}
 
-var target = TargetReportCardApp.initTarget(CHEMBL_ID);
-var TNCView = TargetReportCardApp.initTComponentsView(target, $('#TComponentsCard'));
-target.fetch()
+TargetReportCardApp.initTargetComponents();
 
 {% endblock %}

--- a/glados/templates/glados/TargetReportCardParts/NameAndClassificationToEmbed.html
+++ b/glados/templates/glados/TargetReportCardParts/NameAndClassificationToEmbed.html
@@ -15,8 +15,6 @@
 
 {% block custom_js_inline %}
 
-var target = TargetReportCardApp.initTarget(CHEMBL_ID);
-var TNCView = TargetReportCardApp.initTNCView(target, $('#TNameClassificationCard'));
-target.fetch()
+TargetReportCardApp.initTargetNameAndClassification();
 
 {% endblock %}

--- a/glados/templates/glados/TargetReportCardParts/RelationsToEmbed.html
+++ b/glados/templates/glados/TargetReportCardParts/RelationsToEmbed.html
@@ -15,8 +15,6 @@
 
 {% block custom_js_inline %}
 
-var targetRelations = TargetReportCardApp.initTargetRelations(CHEMBL_ID);
-var tRelView = TargetReportCardApp.initTRelationsView(targetRelations, $('#TRelationsCard'));
-targetRelations.fetch({reset: true});
+TargetReportCardApp.initTargetRelations();
 
 {% endblock %}

--- a/glados/templates/glados/targetReportCard.html
+++ b/glados/templates/glados/targetReportCard.html
@@ -241,24 +241,7 @@
 
 {% block custom_js_inline %}
 
-$('.scrollspy').scrollSpy();
-ScrollSpyHelper.initializeScrollSpyPinner();
-
-var pathname = window.location.pathname;
-var pathnameParts = pathname.split('/')
-CHEMBL_ID = pathnameParts[pathnameParts.length - 2]
-var target = TargetReportCardApp.initTarget(CHEMBL_ID);
-var appDrugsClinCandsList = TargetReportCardApp.initAppDrugClinCands(CHEMBL_ID);
-var targetRelations = TargetReportCardApp.initTargetRelations(CHEMBL_ID);
-
-var tNCView = TargetReportCardApp.initTNCView(target, $('#TNameClassificationCard'));
-var tComponentsView = TargetReportCardApp.initTComponentsView(target, $('#TComponentsCard'));
-var tRelView = TargetReportCardApp.initTRelationsView(targetRelations, $('#TRelationsCard'));
-var adccView = TargetReportCardApp.initADCC(appDrugsClinCandsList, $('#ApprovedDrugsAndClinicalCandidatesCard'));
-
-target.fetch();
-appDrugsClinCandsList.fetch();
-targetRelations.fetch({reset: true});
+TargetReportCardApp.init();
 
 {% endblock %}
 


### PR DESCRIPTION
This pull request continues the work done in https://github.com/chembl/GLaDOS/pull/12. The missing apps for the report card are:

- Assay
- Cell Line
- Compound

Also, following the decision to have one app per page, the different apps and code in general involved with the main page need to be refactored. 