### PR TITLE
Document Word Cloud: Provide a fix for the overflowing words.

### DIFF
--- a/src/glados/static/coffee/views/Document/DocumentWordCloudView.coffee
+++ b/src/glados/static/coffee/views/Document/DocumentWordCloudView.coffee
@@ -16,7 +16,7 @@ DocumentWordCloudView = CardView.extend(ResponsiviseViewExt).extend
       @$vis_elem.html '<i class="fa fa-cog fa-spin fa-2x fa-fw" aria-hidden="true"></i><span class="sr-only">Loading Visualisation...</span><br>'
       @showCardContent()
       @firstTimeRender = false
-      _.delay($.proxy(@render, @), glados.Settings.RESPONSIVE_REPAINT_WAIT * 15)
+      _.delay($.proxy(@render, @), glados.Settings.RESPONSIVE_REPAINT_WAIT * 2)
       return
 
     $description = $(@el).find('.card-description')
@@ -130,6 +130,8 @@ DocumentWordCloudView = CardView.extend(ResponsiviseViewExt).extend
       rotateRatio: 0.0
       classes: 'wordcloud-word'
       backgroundColor: glados.Settings.VISUALISATION_CARD_GREY
+      shuffle: false
+      clearCanvas: true
 
     canvasElem = document.getElementById(elemID)
     WordCloud(canvasElem, config)
@@ -151,7 +153,24 @@ DocumentWordCloudView = CardView.extend(ResponsiviseViewExt).extend
         termEncoded = decodeURIComponent $(@).text()
         window.open('/documents_with_same_terms/' + termEncoded, '_blank')
 
+      ).each( (index, item) ->
+
+        # make sure each element won't overlap that canvas
+        # the problem comes from the wordcloud2.js, this method seems to fix it.
+        $element = $(item)
+        currentLeft = parseFloat($element.css('left'))
+        fontSize = parseFloat($element.css('font-size'))
+        termSize = fontSize * K * $element.text().length
+        outerWidth = $element.outerWidth()
+
+        if termSize > outerWidth
+          console.log 'OVERFLOW!'
+          $element.css('left', currentLeft * 0.3)
+
+
       )
+
+
 
 
 

--- a/src/glados/static/coffee/views/Document/DocumentWordCloudView.coffee
+++ b/src/glados/static/coffee/views/Document/DocumentWordCloudView.coffee
@@ -108,7 +108,6 @@ DocumentWordCloudView = CardView.extend(ResponsiviseViewExt).extend
         if maxFontSize < maxFontLimit
           break
         getFontSizeFor.range([minFont, maxFontSize])
-        console.log 'reset'
 
     getColourFor = d3.scale.linear()
       .domain([minFontSize, maxFontSize])
@@ -164,7 +163,6 @@ DocumentWordCloudView = CardView.extend(ResponsiviseViewExt).extend
         outerWidth = $element.outerWidth()
 
         if termSize > outerWidth
-          console.log 'OVERFLOW!'
           $element.css('left', currentLeft * 0.3)
 
 

--- a/src/glados/static/coffee/views/Document/DocumentWordCloudView.coffee
+++ b/src/glados/static/coffee/views/Document/DocumentWordCloudView.coffee
@@ -16,7 +16,7 @@ DocumentWordCloudView = CardView.extend(ResponsiviseViewExt).extend
       @$vis_elem.html '<i class="fa fa-cog fa-spin fa-2x fa-fw" aria-hidden="true"></i><span class="sr-only">Loading Visualisation...</span><br>'
       @showCardContent()
       @firstTimeRender = false
-      _.delay($.proxy(@render, @), glados.Settings.RESPONSIVE_REPAINT_WAIT * 5)
+      _.delay($.proxy(@render, @), glados.Settings.RESPONSIVE_REPAINT_WAIT * 15)
       return
 
     $description = $(@el).find('.card-description')
@@ -28,6 +28,8 @@ DocumentWordCloudView = CardView.extend(ResponsiviseViewExt).extend
     @initEmbedModal('word_cloud')
     @activateModals()
     @paintWordCloud()
+
+    $(@el).find('.instructions').removeClass('hide')
 
   paintWordCloud: ->
     elemID = @$vis_elem.attr('id')

--- a/src/glados/templates/glados/DocumentReportCardParts/WordCloud.html
+++ b/src/glados/templates/glados/DocumentReportCardParts/WordCloud.html
@@ -15,5 +15,7 @@
 <div id="BCK-DocWordCloud">
 </div>
 
+<div class="instructions hide">
 Click on a term to see other documents with that term.
+</div>
 {% endblock %}

--- a/src/glados/tests/test_targ_rep_card.py
+++ b/src/glados/tests/test_targ_rep_card.py
@@ -126,7 +126,7 @@ class TargetReportCardTest(ReportCardTester):
     self.assertEqual(components_section.value_of_css_property('display'), 'none')
 
   def test_target_report_card_scenario_4(self):
-    self.getURL(self.HOST + '/target_report_card/CHEMBL2363965', self.SLEEP_TIME * 2)
+    self.getURL(self.HOST + '/target_report_card/CHEMBL2363965', self.SLEEP_TIME * 4)
 
     # Protein target classification
     # This one has 60 target components (the highest number in the database), and it only has 2 classifications


### PR DESCRIPTION
The wordcloud.js library seems to have a bug when showing the terms for the first time. Sometimes, they are wider than the container. This pull request provides a fix that will hopefully work in most cases. 