### PR TITLE
Set page size with zoom size

### DIFF
--- a/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionFactory.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionFactory.coffee
@@ -33,6 +33,7 @@ glados.useNameSpace 'glados.models.paginatedCollections',
             columns: esIndexSettings.COLUMNS
             columns_description: esIndexSettings.COLUMNS_DESCRIPTION
             custom_default_card_sizes: esIndexSettings.CUSTOM_DEFAULT_CARD_SIZES
+            custom_card_size_to_page_sizes: esIndexSettings.CUSTOM_CARD_SIZE_TO_PAGE_SIZES
             enable_cards_zoom: esIndexSettings.ENABLE_CARDS_ZOOM
             custom_cards_template: esIndexSettings.CUSTOM_CARDS_TEMPLATE
             custom_cards_item_view: esIndexSettings.CUSTOM_CARDS_ITEM_VIEW

--- a/src/glados/static/coffee/models/paginatedCollections/Settings.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/Settings.coffee
@@ -28,6 +28,13 @@ glados.useNameSpace 'glados.models.paginatedCollections',
           small: 12
           medium: 6
           large: 4
+        CUSTOM_CARD_SIZE_TO_PAGE_SIZES:
+          12: 6
+          6: 12
+          4: 24
+          3: 24
+          2: 96
+          1: 192
         ENABLE_CARDS_ZOOM: true
         CUSTOM_CARDS_TEMPLATE: 'Handlebars-Common-Paginated-Card-Compound'
         CUSTOM_CARDS_ITEM_VIEW: glados.views.PaginatedViews.ItemCardView

--- a/src/glados/static/coffee/views/PaginatedViews/CardZoomFunctions.coffee
+++ b/src/glados/static/coffee/views/PaginatedViews/CardZoomFunctions.coffee
@@ -48,7 +48,8 @@ glados.useNameSpace 'glados.views.PaginatedViews',
         medium: @getNextSize(@CURRENT_CARD_SIZES.medium)
         large: @getNextSize(@CURRENT_CARD_SIZES.large)
 
-      @finishZoom()
+      pageSizeMustBe = @getPageSizeAccordingToZoom()
+      @finishZoom(pageSizeMustBe)
 
     zoomOut: ->
 
@@ -61,8 +62,8 @@ glados.useNameSpace 'glados.views.PaginatedViews',
         medium: @getPreviousSize(@CURRENT_CARD_SIZES.medium)
         large: @getPreviousSize(@CURRENT_CARD_SIZES.large)
 
-      minPageSize = @getMinimunPageSize()
-      @finishZoom(minPageSize)
+      pageSizeMustBe = @getPageSizeAccordingToZoom()
+      @finishZoom(pageSizeMustBe)
 
     resetZoom: ->
 
@@ -75,18 +76,18 @@ glados.useNameSpace 'glados.views.PaginatedViews',
         medium: @DEFAULT_CARDS_SIZES.medium
         large: @DEFAULT_CARDS_SIZES.large
 
-      minPageSize = @getMinimunPageSize()
-      @finishZoom(minPageSize)
+      pageSizeMustBe = @getPageSizeAccordingToZoom()
+      @finishZoom(pageSizeMustBe)
 
-    getMinimunPageSize: ->
+    getPageSizeAccordingToZoom: ->
 
       currentScreenType = GlobalVariables.CURRENT_SCREEN_TYPE
       if currentScreenType == glados.Settings.SMALL_SCREEN
-        return @CARD_SIZE_TO_MIN_PAGE_SIZE[@CURRENT_CARD_SIZES.small]
+        return @CARD_SIZE_TO_PAGE_SIZE[@CURRENT_CARD_SIZES.small]
       else if currentScreenType == glados.Settings.MEDIUM_SCREEN
-        return @CARD_SIZE_TO_MIN_PAGE_SIZE[@CURRENT_CARD_SIZES.medium]
+        return @CARD_SIZE_TO_PAGE_SIZE[@CURRENT_CARD_SIZES.medium]
       else
-        return @CARD_SIZE_TO_MIN_PAGE_SIZE[@CURRENT_CARD_SIZES.large]
+        return @CARD_SIZE_TO_PAGE_SIZE[@CURRENT_CARD_SIZES.large]
 
 
     mustDisableZoomIn: ->

--- a/src/glados/static/coffee/views/PaginatedViews/InfiniteCards.coffee
+++ b/src/glados/static/coffee/views/PaginatedViews/InfiniteCards.coffee
@@ -12,7 +12,7 @@ glados.useNameSpace 'glados.views.PaginatedViews',
     #-------------------------------------------------------------------------------------------------------------------
     # Zoom
     #-------------------------------------------------------------------------------------------------------------------
-    CARD_SIZE_TO_MIN_PAGE_SIZE:
+    CARD_SIZE_TO_PAGE_SIZE:
       12: 50
       6: 50
       4: 50
@@ -20,10 +20,10 @@ glados.useNameSpace 'glados.views.PaginatedViews',
       2: 100
       1: 200
 
-    finishZoom: (minPageSize) ->
+    finishZoom: (pageSizeMustBe) ->
 
-      if @currentPageSize < minPageSize
-        @requestPageSizeInCollection(minPageSize)
+      if @currentPageSize != pageSizeMustBe
+        @requestPageSizeInCollection(pageSizeMustBe)
       else
         @requestPageInCollection(1)
 

--- a/src/glados/static/coffee/views/PaginatedViews/PaginatedCards.coffee
+++ b/src/glados/static/coffee/views/PaginatedViews/PaginatedCards.coffee
@@ -4,6 +4,9 @@ glados.useNameSpace 'glados.views.PaginatedViews',
     initAvailablePageSizes: ->
       @AVAILABLE_PAGE_SIZES = [6, 12, 24, 48, 96, 192]
 
+      if @collection.getMeta('custom_card_size_to_page_sizes')?
+        @CARD_SIZE_TO_PAGE_SIZE = @collection.getMeta('custom_card_size_to_page_sizes')
+
       defaultPageSize = @collection.getMeta('default_page_size')
       if defaultPageSize?
         @currentPageSize = defaultPageSize

--- a/src/glados/static/coffee/views/PaginatedViews/PaginatedCards.coffee
+++ b/src/glados/static/coffee/views/PaginatedViews/PaginatedCards.coffee
@@ -8,12 +8,12 @@ glados.useNameSpace 'glados.views.PaginatedViews',
       if defaultPageSize?
         @currentPageSize = defaultPageSize
       else
-        @currentPageSize = @AVAILABLE_PAGE_SIZES[2]
+        @currentPageSize = @getPageSizeAccordingToZoom()
 
     #-------------------------------------------------------------------------------------------------------------------
     # Zoom
     #-------------------------------------------------------------------------------------------------------------------
-    CARD_SIZE_TO_MIN_PAGE_SIZE:
+    CARD_SIZE_TO_PAGE_SIZE:
       12: 6
       6: 6
       4: 12
@@ -21,10 +21,10 @@ glados.useNameSpace 'glados.views.PaginatedViews',
       2: 96
       1: 192
 
-    finishZoom: (minPageSize) ->
+    finishZoom: (pageSizeMustBe) ->
 
-      if @currentPageSize < minPageSize
-        @requestPageSizeInCollection(minPageSize)
+      if @currentPageSize != pageSizeMustBe
+        @requestPageSizeInCollection(pageSizeMustBe)
       else
         @render()
 


### PR DESCRIPTION
Before, the page size changed only if it was less than the size defined according to the current zoom. Now, when you change the zoom, the page size will always be changed to the corresponding one. 