### PR TITLE
Improve matrix tooltips hiding

### DIFF
--- a/src/glados/static/coffee/Settings.coffee
+++ b/src/glados/static/coffee/Settings.coffee
@@ -136,6 +136,8 @@ glados.useNameSpace 'glados',
     # ranges include both numbers
     VIEW_SELECTION_THRESHOLDS:
       'Bioactivity': [0,1024, 300]
+    TOOLTIPS:
+      DEFAULT_MERCY_TIME: 100
   Events:
     Collections:
       ALL_ITEMS_DOWNLOADED: 'ALL_ITEMS_DOWNLOADED'

--- a/src/glados/static/coffee/Utils.coffee
+++ b/src/glados/static/coffee/Utils.coffee
@@ -308,10 +308,15 @@ glados.useNameSpace 'glados',
     Tooltips:
       # removes all qtips from and element, the elements that have a tooltip must have the property
       # data-qtip-configured set to 'yes'
-      destroyAllTooltips: ($elem) ->
+      destroyAllTooltips: ($elem, withMercy) ->
 
         $elemsWithToolTip = $($elem).find('[data-qtip-configured=yes],[data-qtip-configured=true]')
         $elemsWithToolTip.each (index, elem) ->
+          if $(elem).attr('data-qtip-have-mercy') == 'yes' and withMercy
+            # I have mercy only once
+            $(elem).attr('data-qtip-have-mercy', undefined)
+            return
+
           $(elem).qtip('destroy', true)
           $(elem).attr('data-qtip-configured', null )
 
@@ -338,7 +343,6 @@ glados.useNameSpace 'glados',
         else
           myVert = 'bottom'
           atVert = 'top'
-        console.log 'ELEM data', offset.top, $tooltipContent.height()
         if $tooltipContent and $tooltipContent.height() >= offset.top
           myVert = 'top'
           atVert = 'bottom'
@@ -348,6 +352,7 @@ glados.useNameSpace 'glados',
         }
 
       destroyAllTooltipsWhenMouseIsOut: ($container, mouseX, mouseY)->
+        # This function destroys all tooltips immediately if the mouse is outside the element that the mouse left
 
         scrollTop = $(window).scrollTop()
         scrollLeft = $(window).scrollLeft()
@@ -363,6 +368,14 @@ glados.useNameSpace 'glados',
 
         if xIsOut or yIsOut
           glados.Utils.Tooltips.destroyAllTooltips($($container))
+
+      destroyAllTooltipsWhitMercy: ($container)->
+        # With mercy means that it waits some time (defined in settings) before destroy the tooltips in $container
+        # If an element is saved it is not destroyed. An tooltip is saved when the mouse hovers over it.
+
+        setTimeout (-> glados.Utils.Tooltips.destroyAllTooltips($($container), withMercy=true)),
+          glados.Settings.TOOLTIPS.DEFAULT_MERCY_TIME
+
 
     Fetching:
       fetchModelOnce: (model) ->

--- a/src/glados/static/coffee/views/Visualisation/MatrixView.coffee
+++ b/src/glados/static/coffee/views/Visualisation/MatrixView.coffee
@@ -562,6 +562,7 @@ MatrixView = Backbone.View.extend(ResponsiviseViewExt).extend
       .attr(BASE_Y_TRANS_ATT, 0)
       .attr(MOVE_X_ATT, YES)
       .attr(MOVE_Y_ATT, NO)
+      .classed('BCK-ColsHeaderG', true)
 
     colsHeaderG.append('rect')
       .attr('height', @COLS_HEADER_HEIGHT)
@@ -1025,10 +1026,11 @@ MatrixView = Backbone.View.extend(ResponsiviseViewExt).extend
       qtipConfig =
         content:
           text: '<div id="' + miniRepCardID + '"></div>'
-          button: 'close'
         show:
           solo: true
-        hide: 'click'
+        hide:
+          fixed: true,
+          delay: glados.Settings.TOOLTIPS.DEFAULT_MERCY_TIME
         style:
           classes:'matrix-qtip qtip-light qtip-shadow'
 
@@ -1051,6 +1053,8 @@ MatrixView = Backbone.View.extend(ResponsiviseViewExt).extend
       $clickedElem.attr('data-qtip-configured', 'yes')
 
       $newMiniReportCardContainer = $('#' + miniRepCardID)
+      $newMiniReportCardContainer.hover ->
+        $clickedElem.attr('data-qtip-have-mercy', 'yes')
 
       if entityName == 'Target'
         TargetReportCardApp.initMiniTargetReportCard($newMiniReportCardContainer, chemblID)
@@ -1064,6 +1068,11 @@ MatrixView = Backbone.View.extend(ResponsiviseViewExt).extend
     mouseY = event.clientY
     $elementLeft = $(event.currentTarget)
     glados.Utils.Tooltips.destroyAllTooltipsWhenMouseIsOut($elementLeft, mouseX, mouseY)
+
+  destroyAllTooltipsWithMercy: ->
+
+    $container = $(@el)
+    glados.Utils.Tooltips.destroyAllTooltipsWhitMercy($container)
   #---------------------------------------------------------------------------------------------------------------------
   # cells tooltips
   #---------------------------------------------------------------------------------------------------------------------

--- a/src/glados/static/coffee/views/Visualisation/MatrixView.coffee
+++ b/src/glados/static/coffee/views/Visualisation/MatrixView.coffee
@@ -18,7 +18,8 @@ MatrixView = Backbone.View.extend(ResponsiviseViewExt).extend
     @model.on 'change:state', @handleMatrixState, @
     @model.on glados.models.Activity.ActivityAggregationMatrix.TARGET_PREF_NAMES_UPDATED_EVT, @handleTargetPrefNameChange, @
 
-    $(@el).mouseleave($.proxy(@destroyAllTooltipsIfNecessary, @))
+    $matrixContainer = $(@el).find('.BCK-CompTargMatrixContainer')
+    $matrixContainer.mouseleave(@destroyAllTooltipsIfNecessary)
 
     @$vis_elem = $(@el).find('.BCK-CompTargMatrixContainer')
     #ResponsiviseViewExt
@@ -1061,7 +1062,8 @@ MatrixView = Backbone.View.extend(ResponsiviseViewExt).extend
 
     mouseX = event.clientX
     mouseY = event.clientY
-    glados.Utils.Tooltips.destroyAllTooltipsWhenMouseIsOut($(@el), mouseX, mouseY)
+    $elementLeft = $(event.currentTarget)
+    glados.Utils.Tooltips.destroyAllTooltipsWhenMouseIsOut($elementLeft, mouseX, mouseY)
   #---------------------------------------------------------------------------------------------------------------------
   # cells tooltips
   #---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Now, the tooltips for rows and columns headers hide if not interacted with them in ``` glados.Settings.TOOLTIPS.DEFAULT_MERCY_TIME``` milliseconds. 
This should fix https://github.com/chembl/GLaDOS/issues/447