### PR TITLE
Fix "similar compounds" bug in report card

### DIFF
--- a/src/glados/static/coffee/ReportCardApp.coffee
+++ b/src/glados/static/coffee/ReportCardApp.coffee
@@ -9,10 +9,14 @@ glados.useNameSpace 'glados',
         model: @scrollSpyHandler
 
 
-    @hideSection = (sectionID) -> $('#' + sectionID).hide()
+    @hideSection = (sectionID) ->
+      @scrollSpyHandler.hideSection(sectionID)
+      $('#' + sectionID).hide()
+
     @showSection = (sectionID) ->
       @scrollSpyHandler.showSection(sectionID)
       $('#' + sectionID).show()
+
     @registerSection = (sectionID, sectionLabel) ->
       @scrollSpyHandler.registerSection(sectionID, sectionLabel)
 

--- a/src/glados/static/coffee/compoundReportCardApp.coffee
+++ b/src/glados/static/coffee/compoundReportCardApp.coffee
@@ -359,6 +359,7 @@ class CompoundReportCardApp extends glados.ReportCardApp
       embed_identifier: chemblID
       title: "Compounds similar to #{chemblID} with at least 70% similarity:"
       full_list_url: "/similarity_search_results/#{chemblID}/70"
+      hide_on_error: true
 
     new glados.views.ReportCards.CarouselInCardView
       collection: similarCompoundsList

--- a/src/glados/static/coffee/models/ScrollSpy/ScrollSpyHandler.coffee
+++ b/src/glados/static/coffee/models/ScrollSpy/ScrollSpyHandler.coffee
@@ -17,6 +17,12 @@ glados.useNameSpace 'glados.models.ScrollSpy',
       sections[sectionName].state = glados.models.ScrollSpy.ScrollSpyHandler.SECTION_STATES.SHOW
       @trigger('change:sections')
 
+    hideSection: (sectionName) ->
+      console.log "hiding #{sectionName} section from scroll spy!"
+      sections = @get('sections')
+      sections[sectionName].state = glados.models.ScrollSpy.ScrollSpyHandler.SECTION_STATES.NOT_AVAILABLE
+      @trigger('change:sections')
+
     resetSections: ->
       @set('sections', {})
 

--- a/src/glados/static/coffee/models/ScrollSpy/ScrollSpyHandler.coffee
+++ b/src/glados/static/coffee/models/ScrollSpy/ScrollSpyHandler.coffee
@@ -18,7 +18,6 @@ glados.useNameSpace 'glados.models.ScrollSpy',
       @trigger('change:sections')
 
     hideSection: (sectionName) ->
-      console.log "hiding #{sectionName} section from scroll spy!"
       sections = @get('sections')
       sections[sectionName].state = glados.models.ScrollSpy.ScrollSpyHandler.SECTION_STATES.NOT_AVAILABLE
       @trigger('change:sections')

--- a/src/glados/static/coffee/views/ReportCards/CarouselInCardView.coffee
+++ b/src/glados/static/coffee/views/ReportCards/CarouselInCardView.coffee
@@ -4,9 +4,15 @@ glados.useNameSpace 'glados.views.ReportCards',
     initialize: ->
 
       CardView.prototype.initialize.call(@, arguments)
-      @collection.on 'reset', @.render, @
-      @collection.on 'error', @.showCompoundErrorCard, @
       @config = arguments[0].config
+
+      @collection.on 'reset', @.render, @
+
+      if @config.hide_on_error
+        @collection.on 'error', @hideSection, @
+      else
+        @collection.on 'error', @.showCompoundErrorCard, @
+
       @resource_type = arguments[0].resource_type
       @paginatedView = glados.views.PaginatedViews.PaginatedViewFactory.getNewCardsCarouselView(@collection, @el)
 

--- a/src/glados/static/coffee/views/base/CardView.coffee
+++ b/src/glados/static/coffee/views/base/CardView.coffee
@@ -14,7 +14,7 @@ CardView = Backbone.View.extend
 
   showCompoundErrorCard: (model, xhr, options) ->
 
-    $(@el).children('.card-preolader-to-hide').hide()
+    $(@el).find('.card-preolader-to-hide').hide()
 
     if xhr.status == 404
 
@@ -31,9 +31,8 @@ CardView = Backbone.View.extend
     rendered = Handlebars.compile($('#Handlebars-Common-CardError').html())
       msg: error_msg
 
-    $(@el).children('.card-load-error').find('.Bck-errormsg').html(rendered)
-
-    $(@el).children('.card-load-error').show()
+    $(@el).find('.card-load-error').find('.Bck-errormsg').html(rendered)
+    $(@el).find('.card-load-error').show()
 
 
   initEmbedModal: (section_name, chemblID) ->

--- a/src/glados/static/coffee/views/base/CardView.coffee
+++ b/src/glados/static/coffee/views/base/CardView.coffee
@@ -31,8 +31,8 @@ CardView = Backbone.View.extend
     rendered = Handlebars.compile($('#Handlebars-Common-CardError').html())
       msg: error_msg
 
-    $(@el).find('.card-load-error').find('.Bck-errormsg').html(rendered)
-    $(@el).find('.card-load-error').show()
+    $(@el).find('.card-load-error').find('.Bck-errormsg').first().html(rendered)
+    $(@el).find('.card-load-error').first().show()
 
 
   initEmbedModal: (section_name, chemblID) ->

--- a/src/glados/static/coffee/views/base/CardView.coffee
+++ b/src/glados/static/coffee/views/base/CardView.coffee
@@ -11,6 +11,7 @@ CardView = Backbone.View.extend
       @reportCardApp.registerSection(@sectionID, @sectionLabel)
 
   showSection: -> @reportCardApp.showSection(@sectionID) unless GlobalVariables['EMBEDED']
+  hideSection: -> @reportCardApp.hideSection(@sectionID) unless GlobalVariables['EMBEDED']
 
   showCompoundErrorCard: (model, xhr, options) ->
 


### PR DESCRIPTION
This fixes how the section is shown when there is no structure available to get the similarity. For example when this happens: https://www.ebi.ac.uk/chembl/api/data/similarity.json?limit=2&offset=0&similarity=70&chembl_id=CHEMBL1201585