### PR TITLE
Fix link to all activities bugs

### DIFF
--- a/src/glados/static/coffee/Settings.coffee
+++ b/src/glados/static/coffee/Settings.coffee
@@ -185,7 +185,7 @@ glados.useNameSpace 'glados',
      # If there is a value here, it means that the view is enable only if there is a certain number of items selected.
     # ranges include both numbers
     VIEW_SELECTION_THRESHOLDS:
-      'Bioactivity': [0,1024, 300]
+      Heatmap: [0,1024, 300]
     TOOLTIPS:
       DEFAULT_MERCY_TIME: 100
   Events:

--- a/src/glados/static/coffee/Settings.coffee
+++ b/src/glados/static/coffee/Settings.coffee
@@ -186,6 +186,7 @@ glados.useNameSpace 'glados',
     # ranges include both numbers
     VIEW_SELECTION_THRESHOLDS:
       Heatmap: [0,1024, 300]
+    VIEWS_DISABLED_WHILE_STREAMING: ['Heatmap', 'Graph']
     TOOLTIPS:
       DEFAULT_MERCY_TIME: 100
   Events:

--- a/src/glados/static/coffee/models/paginatedCollections/ESPaginatedQueryCollection.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/ESPaginatedQueryCollection.coffee
@@ -237,6 +237,7 @@ glados.useNameSpace 'glados.models.paginatedCollections',
       if _.isUndefined(facets_data.aggregations)
         for facet_group_key, facet_group of @getFacetsGroups(true)
           facet_group.faceting_handler.parseESResults(facets_data.aggregations)
+        @setFacetsFetchingState(glados.models.paginatedCollections.PaginatedCollectionBase.FACETS_FETCHING_STATES.FACETS_READY)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Elastic Search Query structure

--- a/src/glados/static/coffee/models/paginatedCollections/ESPaginatedQueryCollection.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/ESPaginatedQueryCollection.coffee
@@ -202,6 +202,7 @@ glados.useNameSpace 'glados.models.paginatedCollections',
         @setMeta('current_page', 1)
         @setMeta('facets_changed', false)
         @setMeta('ignore_score', true)
+        @setFecthingState(glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES.FILTERING_ITEMS)
       else
         @setFecthingState(glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES.FETCHING_ITEMS)
       # Creates the Elastic Search Query parameters and serializes them
@@ -521,6 +522,8 @@ glados.useNameSpace 'glados.models.paginatedCollections',
       for fGroupKey, fGroup of @getFacetsGroups(true, onlyVisible=false)
         fGroup.faceting_handler.clearSelections()
 
+      if @getMeta('test_mode')
+        return
       @setMeta('facets_changed', true)
       @fetch()
 

--- a/src/glados/static/coffee/models/paginatedCollections/ESPaginatedQueryCollection.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/ESPaginatedQueryCollection.coffee
@@ -423,6 +423,16 @@ glados.useNameSpace 'glados.models.paginatedCollections',
     # ------------------------------------------------------------------------------------------------------------------
     # Elastic Search Facets request
     # ------------------------------------------------------------------------------------------------------------------
+    # returns true if the final state of the facet is selected, false otherwise
+    toggleFacetAndFetch: (fGroupKey, fKey) ->
+
+      facetsGroups = @getFacetsGroups()
+      facetingHandler = facetsGroups[fGroupKey].faceting_handler
+      isSelected = facetingHandler.toggleKeySelection(fKey)
+      @setMeta('facets_changed', true)
+      @fetch()
+
+      return isSelected
 
     __requestFacetsGroupsData: (first_call)->
       es_url = @getURL()

--- a/src/glados/static/coffee/models/paginatedCollections/ESPaginatedQueryCollection.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/ESPaginatedQueryCollection.coffee
@@ -202,9 +202,8 @@ glados.useNameSpace 'glados.models.paginatedCollections',
         @setMeta('current_page', 1)
         @setMeta('facets_changed', false)
         @setMeta('ignore_score', true)
-        @setFecthingState(glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES.FILTERING_ITEMS)
-      else
-        @setFecthingState(glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES.FETCHING_ITEMS)
+
+      @setItemsFetchingState(glados.models.paginatedCollections.PaginatedCollectionBase.ITEMS_FETCHING_STATES.FETCHING_ITEMS)
       # Creates the Elastic Search Query parameters and serializes them
       requestData = @getRequestData()
       esJSONRequest = JSON.stringify(@getRequestData())
@@ -493,7 +492,13 @@ glados.useNameSpace 'glados.models.paginatedCollections',
       else
         runPromise.bind(@)()
 
-    loadFacetGroups: ()->
+    loadFacetGroups: ->
+
+      @setFacetsFetchingState(glados.models.paginatedCollections.PaginatedCollectionBase.FACETS_FETCHING_STATES.FETCHING_FACETS)
+
+      if @getMeta('test_mode')
+        return
+
       if not @__debouncedLoadFacetGroups?
         @__debouncedLoadFacetGroups = _.debounce(@__loadFacetGroups, 10)
       @__debouncedLoadFacetGroups()

--- a/src/glados/static/coffee/models/paginatedCollections/ESPaginatedQueryCollection.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/ESPaginatedQueryCollection.coffee
@@ -226,19 +226,7 @@ glados.useNameSpace 'glados.models.paginatedCollections',
 
       # Call Backbone's fetch
       return Backbone.Collection.prototype.fetch.call(this, fetchESOptions)
-
-
-    # ------------------------------------------------------------------------------------------------------------------
-    # Parse/Fetch Facets Groups data
-    # ------------------------------------------------------------------------------------------------------------------
     
-    # Parses the facets groups aggregations data
-    parseFacetsGroups: (facets_data)->
-      if _.isUndefined(facets_data.aggregations)
-        for facet_group_key, facet_group of @getFacetsGroups(true)
-          facet_group.faceting_handler.parseESResults(facets_data.aggregations)
-        @setFacetsFetchingState(glados.models.paginatedCollections.PaginatedCollectionBase.FACETS_FETCHING_STATES.FACETS_READY)
-
     # ------------------------------------------------------------------------------------------------------------------
     # Elastic Search Query structure
     # ------------------------------------------------------------------------------------------------------------------

--- a/src/glados/static/coffee/models/paginatedCollections/ESPaginatedQueryCollection.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/ESPaginatedQueryCollection.coffee
@@ -186,6 +186,9 @@ glados.useNameSpace 'glados.models.paginatedCollections',
 
       @setMeta('last_page_results_ids', curPageResultsIds)
 
+      #if this causes problems this can be moved to a custom reset function
+      @setItemsFetchingState(glados.models.paginatedCollections.PaginatedCollectionBase.ITEMS_FETCHING_STATES.ITEMS_READY)
+
       return jsonResultsList
 
     # Prepares an Elastic Search query to search in all the fields of a document in a specific index

--- a/src/glados/static/coffee/models/paginatedCollections/ESPaginatedQueryCollection.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/ESPaginatedQueryCollection.coffee
@@ -191,6 +191,7 @@ glados.useNameSpace 'glados.models.paginatedCollections',
     # Prepares an Elastic Search query to search in all the fields of a document in a specific index
     fetch: (options, testMode=false) ->
 
+      testMode |= @getMeta('test_mode')
       @trigger('before_fetch_elastic')
       @url = @getURL()
 
@@ -201,7 +202,8 @@ glados.useNameSpace 'glados.models.paginatedCollections',
         @setMeta('current_page', 1)
         @setMeta('facets_changed', false)
         @setMeta('ignore_score', true)
-
+      else
+        @setFecthingState(glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES.FETCHING_ITEMS)
       # Creates the Elastic Search Query parameters and serializes them
       requestData = @getRequestData()
       esJSONRequest = JSON.stringify(@getRequestData())

--- a/src/glados/static/coffee/models/paginatedCollections/ESPaginatedQueryCollection.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/ESPaginatedQueryCollection.coffee
@@ -226,7 +226,7 @@ glados.useNameSpace 'glados.models.paginatedCollections',
 
       # Call Backbone's fetch
       return Backbone.Collection.prototype.fetch.call(this, fetchESOptions)
-    
+
     # ------------------------------------------------------------------------------------------------------------------
     # Elastic Search Query structure
     # ------------------------------------------------------------------------------------------------------------------
@@ -477,6 +477,7 @@ glados.useNameSpace 'glados.models.paginatedCollections',
         @__last_facets_promise = new Promise(promiseFunc.bind(@))
         triggerEvent = ()->
           @trigger('facets-changed')
+          @setFacetsFetchingState(glados.models.paginatedCollections.PaginatedCollectionBase.FACETS_FETCHING_STATES.FACETS_READY)
         @__last_facets_promise.then(triggerEvent.bind(@))
 
       if @__last_facets_promise?

--- a/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
@@ -95,13 +95,21 @@ glados.useNameSpace 'glados.models.paginatedCollections',
     # ------------------------------------------------------------------------------------------------------------------
     getItemsFetchingState: -> @getMeta('items_fetching_state')
     getFacetsFetchingState: -> @getMeta('facets_fetching_state')
-    setItemsFetchingState: (newFetchingState) -> @setMeta('items_fetching_state', newFetchingState)
-    setFacetsFetchingState: (newFetchingState) -> @setMeta('facets_fetching_state', newFetchingState)
+    setItemsFetchingState: (newFetchingState) ->
+      @trigger(glados.models.paginatedCollections.PaginatedCollectionBase.EVENTS.ITEMS_FETCHING_STATE_CHANGED)
+      @setMeta('items_fetching_state', newFetchingState)
+    setFacetsFetchingState: (newFetchingState) ->
+      @trigger(glados.models.paginatedCollections.PaginatedCollectionBase.EVENTS.FACETS_FETCHING_STATE_CHANGED)
+      @setMeta('facets_fetching_state', newFetchingState)
     setInitialFetchingState: ->
       @setMeta('items_fetching_state',
         glados.models.paginatedCollections.PaginatedCollectionBase.ITEMS_FETCHING_STATES.INITIAL_STATE)
       @setMeta('facets_fetching_state',
         glados.models.paginatedCollections.PaginatedCollectionBase.FACETS_FETCHING_STATES.INITIAL_STATE)
+
+glados.models.paginatedCollections.PaginatedCollectionBase.EVENTS =
+  ITEMS_FETCHING_STATE_CHANGED: 'ITEMS_FETCHING_STATE_CHANGED'
+  FACETS_FETCHING_STATE_CHANGED: 'FACETS_FETCHING_STATE_CHANGED'
 
 glados.models.paginatedCollections.PaginatedCollectionBase.ITEMS_FETCHING_STATES =
   INITIAL_STATE: 'INITIAL_STATE'

--- a/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
@@ -106,6 +106,7 @@ glados.useNameSpace 'glados.models.paginatedCollections',
 glados.models.paginatedCollections.PaginatedCollectionBase.ITEMS_FETCHING_STATES =
   INITIAL_STATE: 'INITIAL_STATE'
   FETCHING_ITEMS: 'FETCHING_ITEMS'
+  ITEMS_READY: 'ITEMS_READY'
 
 glados.models.paginatedCollections.PaginatedCollectionBase.FACETS_FETCHING_STATES =
   INITIAL_STATE: 'INITIAL_STATE'

--- a/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
@@ -93,13 +93,20 @@ glados.useNameSpace 'glados.models.paginatedCollections',
     # ------------------------------------------------------------------------------------------------------------------
     # Fetching state handling
     # ------------------------------------------------------------------------------------------------------------------
-    getFetchingState: -> @getMeta('fetching_state')
-    setFecthingState: (newFetchingState) -> @setMeta('fetching_state', newFetchingState)
+    getItemsFetchingState: -> @getMeta('items_fetching_state')
+    getFacetsFetchingState: -> @getMeta('facets_fetching_state')
+    setItemsFetchingState: (newFetchingState) -> @setMeta('items_fetching_state', newFetchingState)
+    setFacetsFetchingState: (newFetchingState) -> @setMeta('facets_fetching_state', newFetchingState)
     setInitialFetchingState: ->
-      @setMeta('fetching_state',
-        glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES.INITIAL_STATE)
+      @setMeta('items_fetching_state',
+        glados.models.paginatedCollections.PaginatedCollectionBase.ITEMS_FETCHING_STATES.INITIAL_STATE)
+      @setMeta('facets_fetching_state',
+        glados.models.paginatedCollections.PaginatedCollectionBase.FACETS_FETCHING_STATES.INITIAL_STATE)
 
-glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES =
+glados.models.paginatedCollections.PaginatedCollectionBase.ITEMS_FETCHING_STATES =
   INITIAL_STATE: 'INITIAL_STATE'
   FETCHING_ITEMS: 'FETCHING_ITEMS'
-  FILTERING_ITEMS: 'FILTERING_ITEMS'
+
+glados.models.paginatedCollections.PaginatedCollectionBase.FACETS_FETCHING_STATES =
+  INITIAL_STATE: 'INITIAL_STATE'
+  FETCHING_FACETS: 'FETCHING_FACETS'

--- a/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
@@ -111,3 +111,4 @@ glados.models.paginatedCollections.PaginatedCollectionBase.ITEMS_FETCHING_STATES
 glados.models.paginatedCollections.PaginatedCollectionBase.FACETS_FETCHING_STATES =
   INITIAL_STATE: 'INITIAL_STATE'
   FETCHING_FACETS: 'FETCHING_FACETS'
+  FACETS_READY: 'FACETS_READY'

--- a/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
@@ -4,6 +4,7 @@ glados.useNameSpace 'glados.models.paginatedCollections',
 
     initialize: ->
 
+      @setInitialFetchingState()
       if @islinkToAllActivitiesEnabled()
         @on glados.Events.Collections.SELECTION_UPDATED, @resetLinkToAllActivitiesCache, @
 
@@ -88,3 +89,14 @@ glados.useNameSpace 'glados.models.paginatedCollections',
       Handlebars.compile('_metadata.assay_data.tissue_chembl_id:({{#each ids}}"{{this}}"{{#unless @last}} OR {{/unless}}{{/each}})')
       "#{glados.models.Compound.Drug}":\
       Handlebars.compile('molecule_chembl_id:({{#each ids}}"{{this}}"{{#unless @last}} OR {{/unless}}{{/each}})')
+
+    # ------------------------------------------------------------------------------------------------------------------
+    # Fetching state handling
+    # ------------------------------------------------------------------------------------------------------------------
+    getFetchingState: -> @getMeta('fetching_state')
+    setInitialFetchingState: ->
+      @setMeta('fetching_state',
+        glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES.INITIAL_STATE)
+
+glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES =
+  INITIAL_STATE: 'INITIAL_STATE'

--- a/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
@@ -94,9 +94,11 @@ glados.useNameSpace 'glados.models.paginatedCollections',
     # Fetching state handling
     # ------------------------------------------------------------------------------------------------------------------
     getFetchingState: -> @getMeta('fetching_state')
+    setFecthingState: (newFetchingState) -> @setMeta('fetching_state', newFetchingState)
     setInitialFetchingState: ->
       @setMeta('fetching_state',
         glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES.INITIAL_STATE)
 
 glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES =
   INITIAL_STATE: 'INITIAL_STATE'
+  FETCHING_ITEMS: 'FETCHING_ITEMS'

--- a/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
@@ -40,7 +40,7 @@ glados.useNameSpace 'glados.models.paginatedCollections',
 
       numSelectedItems = @getNumberOfSelectedItems()
       numItemsForLink = if numSelectedItems == 0 then @getTotalRecords() else numSelectedItems
-      if numItemsForLink >= glados.Settings.VIEW_SELECTION_THRESHOLDS.Bioactivity[1]
+      if numItemsForLink >= glados.Settings.VIEW_SELECTION_THRESHOLDS.Heatmap[1]
         return true
       return false
 

--- a/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
@@ -96,11 +96,11 @@ glados.useNameSpace 'glados.models.paginatedCollections',
     getItemsFetchingState: -> @getMeta('items_fetching_state')
     getFacetsFetchingState: -> @getMeta('facets_fetching_state')
     setItemsFetchingState: (newFetchingState) ->
-      @trigger(glados.models.paginatedCollections.PaginatedCollectionBase.EVENTS.ITEMS_FETCHING_STATE_CHANGED)
       @setMeta('items_fetching_state', newFetchingState)
+      @trigger(glados.models.paginatedCollections.PaginatedCollectionBase.EVENTS.ITEMS_FETCHING_STATE_CHANGED)
     setFacetsFetchingState: (newFetchingState) ->
-      @trigger(glados.models.paginatedCollections.PaginatedCollectionBase.EVENTS.FACETS_FETCHING_STATE_CHANGED)
       @setMeta('facets_fetching_state', newFetchingState)
+      @trigger(glados.models.paginatedCollections.PaginatedCollectionBase.EVENTS.FACETS_FETCHING_STATE_CHANGED)
     setInitialFetchingState: ->
       @setMeta('items_fetching_state',
         glados.models.paginatedCollections.PaginatedCollectionBase.ITEMS_FETCHING_STATES.INITIAL_STATE)
@@ -111,14 +111,15 @@ glados.useNameSpace 'glados.models.paginatedCollections',
 
       itemsAreReady = @getMeta('items_fetching_state') == \
       glados.models.paginatedCollections.PaginatedCollectionBase.ITEMS_FETCHING_STATES.ITEMS_READY
-      console.log 'itemsAreReady: ', itemsAreReady
       return itemsAreReady
 
-    collectionIsReady: ->
-      console.log 'itemsAreReady: ', @itemsAreReady()
+    facetsAreReady: ->
+
       facetsAreReady = @getMeta('facets_fetching_state') == \
       glados.models.paginatedCollections.PaginatedCollectionBase.FACETS_FETCHING_STATES.FACETS_READY
-      console.log 'facetsAreReady: ', facetsAreReady
+      return facetsAreReady
+
+    isReady: -> @itemsAreReady() and @facetsAreReady()
 
 glados.models.paginatedCollections.PaginatedCollectionBase.EVENTS =
   ITEMS_FETCHING_STATE_CHANGED: 'ITEMS_FETCHING_STATE_CHANGED'

--- a/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
@@ -107,6 +107,19 @@ glados.useNameSpace 'glados.models.paginatedCollections',
       @setMeta('facets_fetching_state',
         glados.models.paginatedCollections.PaginatedCollectionBase.FACETS_FETCHING_STATES.INITIAL_STATE)
 
+    itemsAreReady: ->
+
+      itemsAreReady = @getMeta('items_fetching_state') == \
+      glados.models.paginatedCollections.PaginatedCollectionBase.ITEMS_FETCHING_STATES.ITEMS_READY
+      console.log 'itemsAreReady: ', itemsAreReady
+      return itemsAreReady
+
+    collectionIsReady: ->
+      console.log 'itemsAreReady: ', @itemsAreReady()
+      facetsAreReady = @getMeta('facets_fetching_state') == \
+      glados.models.paginatedCollections.PaginatedCollectionBase.FACETS_FETCHING_STATES.FACETS_READY
+      console.log 'facetsAreReady: ', facetsAreReady
+
 glados.models.paginatedCollections.PaginatedCollectionBase.EVENTS =
   ITEMS_FETCHING_STATE_CHANGED: 'ITEMS_FETCHING_STATE_CHANGED'
   FACETS_FETCHING_STATE_CHANGED: 'FACETS_FETCHING_STATE_CHANGED'

--- a/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
+++ b/src/glados/static/coffee/models/paginatedCollections/PaginatedCollectionBase.coffee
@@ -102,3 +102,4 @@ glados.useNameSpace 'glados.models.paginatedCollections',
 glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES =
   INITIAL_STATE: 'INITIAL_STATE'
   FETCHING_ITEMS: 'FETCHING_ITEMS'
+  FILTERING_ITEMS: 'FILTERING_ITEMS'

--- a/src/glados/static/coffee/tests/PaginatedCollections/ESPaginatedCollections/FetchingStateTests.coffee
+++ b/src/glados/static/coffee/tests/PaginatedCollections/ESPaginatedCollections/FetchingStateTests.coffee
@@ -2,6 +2,25 @@ describe "An elasticsearch collection", ->
 
   describe 'Fetching State ', ->
 
-    it 'work!!s', ->
+    esList = undefined
+    searchESQuery = JSON.parse('{"bool":{"boost":1,"must":{"bool":{"should":[{"multi_match":{"type":"most_fields","fields":["*.std_analyzed^1.6","*.eng_analyzed^0.8","*.ws_analyzed^1.4","*.keyword^2","*.lower_case_keyword^1.5","*.alphanumeric_lowercase_keyword^1.3"],"query":"Aspirin","fuzziness":0,"minimum_should_match":"100%","boost":10}},{"multi_match":{"type":"best_fields","fields":["*.std_analyzed^1.6","*.eng_analyzed^0.8","*.ws_analyzed^1.4","*.keyword^2","*.lower_case_keyword^1.5","*.alphanumeric_lowercase_keyword^1.3"],"query":"Aspirin","fuzziness":0,"minimum_should_match":"100%","boost":2}},{"multi_match":{"type":"phrase","fields":["*.std_analyzed^1.6","*.eng_analyzed^0.8","*.ws_analyzed^1.4","*.keyword^2","*.lower_case_keyword^1.5","*.alphanumeric_lowercase_keyword^1.3"],"query":"Aspirin","minimum_should_match":"100%","boost":1.5}},{"multi_match":{"type":"phrase_prefix","fields":["*.std_analyzed^1.6","*.eng_analyzed^0.8","*.ws_analyzed^1.4","*.keyword^2","*.lower_case_keyword^1.5","*.alphanumeric_lowercase_keyword^1.3"],"query":"Aspirin","minimum_should_match":"100%"}},{"multi_match":{"type":"most_fields","fields":["*.entity_id^2","*.id_reference^1.5","*.chembl_id^2","*.chembl_id_reference^1.5"],"query":"Aspirin","fuzziness":0,"boost":10}}],"must":[]}},"filter":[]}}')
+
+    beforeAll (done) ->
+
+      esList = glados.models.paginatedCollections.PaginatedCollectionFactory.getAllESResultsListDict()[\
+      glados.models.paginatedCollections.Settings.ES_INDEXES.COMPOUND.KEY_NAME
+      ]
+      esList.setMeta('searchESQuery', searchESQuery)
+      esList.setMeta('test_mode', true)
+      TestsUtils.simulateFacetsESList(esList, glados.Settings.STATIC_URL + 'testData/FacetsTestData.json', done)
+
+    beforeEach ->
+      esList.setMeta('test_mode', true)
+      esList.clearAllFacetsSelections()
 
 
+    it 'sets the initial fecthing state', ->
+
+      stateGot = esList.getFetchingState()
+      stateMustBe = glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES.INITIAL_STATE
+      expect(stateGot).toBe(stateMustBe)

--- a/src/glados/static/coffee/tests/PaginatedCollections/ESPaginatedCollections/FetchingStateTests.coffee
+++ b/src/glados/static/coffee/tests/PaginatedCollections/ESPaginatedCollections/FetchingStateTests.coffee
@@ -15,12 +15,19 @@ describe "An elasticsearch collection", ->
       TestsUtils.simulateFacetsESList(esList, glados.Settings.STATIC_URL + 'testData/FacetsTestData.json', done)
 
     beforeEach ->
+      esList.setInitialFetchingState()
       esList.setMeta('test_mode', true)
       esList.clearAllFacetsSelections()
-
 
     it 'sets the initial fecthing state', ->
 
       stateGot = esList.getFetchingState()
       stateMustBe = glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES.INITIAL_STATE
+      expect(stateGot).toBe(stateMustBe)
+
+    it 'sets the correct state when fetching items', ->
+
+      esList.fetch()
+      stateGot = esList.getFetchingState()
+      stateMustBe = glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES.FETCHING_ITEMS
       expect(stateGot).toBe(stateMustBe)

--- a/src/glados/static/coffee/tests/PaginatedCollections/ESPaginatedCollections/FetchingStateTests.coffee
+++ b/src/glados/static/coffee/tests/PaginatedCollections/ESPaginatedCollections/FetchingStateTests.coffee
@@ -21,15 +21,19 @@ describe "An elasticsearch collection", ->
 
     it 'sets the initial fecthing state', ->
 
-      stateGot = esList.getFetchingState()
-      stateMustBe = glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES.INITIAL_STATE
-      expect(stateGot).toBe(stateMustBe)
+      itemsStateGot = esList.getItemsFetchingState()
+      itemsStateMustBe = glados.models.paginatedCollections.PaginatedCollectionBase.ITEMS_FETCHING_STATES.INITIAL_STATE
+      expect(itemsStateGot).toBe(itemsStateMustBe)
+
+      facetsStateGot = esList.getFacetsFetchingState()
+      facetsStateMustBe = glados.models.paginatedCollections.PaginatedCollectionBase.FACETS_FETCHING_STATES.INITIAL_STATE
+      expect(facetsStateGot).toBe(facetsStateMustBe)
 
     it 'sets the correct state when fetching items', ->
 
       esList.fetch()
-      stateGot = esList.getFetchingState()
-      stateMustBe = glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES.FETCHING_ITEMS
+      stateGot = esList.getItemsFetchingState()
+      stateMustBe = glados.models.paginatedCollections.PaginatedCollectionBase.ITEMS_FETCHING_STATES.FETCHING_ITEMS
       expect(stateGot).toBe(stateMustBe)
 
     it 'sets the correct state when filtering items (selecting a facet)', ->
@@ -38,7 +42,12 @@ describe "An elasticsearch collection", ->
       testFacetGroupKey = 'max_phase'
       testFacetKey = facetGroups[testFacetGroupKey].faceting_handler.faceting_keys_inorder[0]
       esList.toggleFacetAndFetch(testFacetGroupKey, testFacetKey)
-      stateGot = esList.getFetchingState()
+      itemsStateGot = esList.getItemsFetchingState()
 
-      stateMustBe = glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES.FILTERING_ITEMS
-      expect(stateGot).toBe(stateMustBe)
+      itemsStateMustBe = glados.models.paginatedCollections.PaginatedCollectionBase.ITEMS_FETCHING_STATES.FETCHING_ITEMS
+      expect(itemsStateGot).toBe(itemsStateMustBe)
+
+      esList.loadFacetGroups()
+      facetsStateGot = esList.getFacetsFetchingState()
+      facetsStateMustBe = glados.models.paginatedCollections.PaginatedCollectionBase.FACETS_FETCHING_STATES.FETCHING_FACETS
+      expect(facetsStateGot).toBe(facetsStateMustBe)

--- a/src/glados/static/coffee/tests/PaginatedCollections/ESPaginatedCollections/FetchingStateTests.coffee
+++ b/src/glados/static/coffee/tests/PaginatedCollections/ESPaginatedCollections/FetchingStateTests.coffee
@@ -80,3 +80,20 @@ describe "An elasticsearch collection", ->
 
         done()
 
+    it 'triggers the correct event when changing items fetching state', ->
+
+      eventTriggered = false
+      esList.on glados.models.paginatedCollections.PaginatedCollectionBase.EVENTS.ITEMS_FETCHING_STATE_CHANGED,
+      (-> eventTriggered = true)
+
+      esList.setItemsFetchingState(glados.models.paginatedCollections.PaginatedCollectionBase.ITEMS_FETCHING_STATES.INITIAL_STATE)
+      expect(eventTriggered).toBe(true)
+
+    it 'triggers the correct event when changing facets fetching state', ->
+
+      eventTriggered = false
+      esList.on glados.models.paginatedCollections.PaginatedCollectionBase.EVENTS.FACETS_FETCHING_STATE_CHANGED,
+      (-> eventTriggered = true)
+
+      esList.setFacetsFetchingState(glados.models.paginatedCollections.PaginatedCollectionBase.FACETS_FETCHING_STATES.INITIAL_STATE)
+      expect(eventTriggered).toBe(true)

--- a/src/glados/static/coffee/tests/PaginatedCollections/ESPaginatedCollections/FetchingStateTests.coffee
+++ b/src/glados/static/coffee/tests/PaginatedCollections/ESPaginatedCollections/FetchingStateTests.coffee
@@ -1,0 +1,7 @@
+describe "An elasticsearch collection", ->
+
+  describe 'Fetching State ', ->
+
+    it 'work!!s', ->
+
+

--- a/src/glados/static/coffee/tests/PaginatedCollections/ESPaginatedCollections/FetchingStateTests.coffee
+++ b/src/glados/static/coffee/tests/PaginatedCollections/ESPaginatedCollections/FetchingStateTests.coffee
@@ -4,6 +4,7 @@ describe "An elasticsearch collection", ->
 
     esList = undefined
     searchESQuery = JSON.parse('{"bool":{"boost":1,"must":{"bool":{"should":[{"multi_match":{"type":"most_fields","fields":["*.std_analyzed^1.6","*.eng_analyzed^0.8","*.ws_analyzed^1.4","*.keyword^2","*.lower_case_keyword^1.5","*.alphanumeric_lowercase_keyword^1.3"],"query":"Aspirin","fuzziness":0,"minimum_should_match":"100%","boost":10}},{"multi_match":{"type":"best_fields","fields":["*.std_analyzed^1.6","*.eng_analyzed^0.8","*.ws_analyzed^1.4","*.keyword^2","*.lower_case_keyword^1.5","*.alphanumeric_lowercase_keyword^1.3"],"query":"Aspirin","fuzziness":0,"minimum_should_match":"100%","boost":2}},{"multi_match":{"type":"phrase","fields":["*.std_analyzed^1.6","*.eng_analyzed^0.8","*.ws_analyzed^1.4","*.keyword^2","*.lower_case_keyword^1.5","*.alphanumeric_lowercase_keyword^1.3"],"query":"Aspirin","minimum_should_match":"100%","boost":1.5}},{"multi_match":{"type":"phrase_prefix","fields":["*.std_analyzed^1.6","*.eng_analyzed^0.8","*.ws_analyzed^1.4","*.keyword^2","*.lower_case_keyword^1.5","*.alphanumeric_lowercase_keyword^1.3"],"query":"Aspirin","minimum_should_match":"100%"}},{"multi_match":{"type":"most_fields","fields":["*.entity_id^2","*.id_reference^1.5","*.chembl_id^2","*.chembl_id_reference^1.5"],"query":"Aspirin","fuzziness":0,"boost":10}}],"must":[]}},"filter":[]}}')
+    testDataToParse = undefined
 
     beforeAll (done) ->
 
@@ -13,6 +14,13 @@ describe "An elasticsearch collection", ->
       esList.setMeta('searchESQuery', searchESQuery)
       esList.setMeta('test_mode', true)
       TestsUtils.simulateFacetsESList(esList, glados.Settings.STATIC_URL + 'testData/FacetsTestData.json', done)
+
+    beforeAll (done) ->
+
+      dataURL = glados.Settings.STATIC_URL + 'testData/ESCollectionTestData1.json'
+      $.get dataURL, (testData) ->
+        testDataToParse = testData
+        done()
 
     beforeEach ->
       esList.setInitialFetchingState()
@@ -51,3 +59,11 @@ describe "An elasticsearch collection", ->
       facetsStateGot = esList.getFacetsFetchingState()
       facetsStateMustBe = glados.models.paginatedCollections.PaginatedCollectionBase.FACETS_FETCHING_STATES.FETCHING_FACETS
       expect(facetsStateGot).toBe(facetsStateMustBe)
+
+    it 'sets the correct state after parsing items', ->
+
+      esList.reset(esList.parse(testDataToParse))
+
+      itemsStateGot = esList.getItemsFetchingState()
+      itemsStateMustBe = glados.models.paginatedCollections.PaginatedCollectionBase.ITEMS_FETCHING_STATES.ITEMS_READY
+      expect(itemsStateGot).toBe(itemsStateMustBe)

--- a/src/glados/static/coffee/tests/PaginatedCollections/ESPaginatedCollections/FetchingStateTests.coffee
+++ b/src/glados/static/coffee/tests/PaginatedCollections/ESPaginatedCollections/FetchingStateTests.coffee
@@ -31,3 +31,14 @@ describe "An elasticsearch collection", ->
       stateGot = esList.getFetchingState()
       stateMustBe = glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES.FETCHING_ITEMS
       expect(stateGot).toBe(stateMustBe)
+
+    it 'sets the correct state when filtering items (selecting a facet)', ->
+
+      facetGroups = esList.getFacetsGroups()
+      testFacetGroupKey = 'max_phase'
+      testFacetKey = facetGroups[testFacetGroupKey].faceting_handler.faceting_keys_inorder[0]
+      esList.toggleFacetAndFetch(testFacetGroupKey, testFacetKey)
+      stateGot = esList.getFetchingState()
+
+      stateMustBe = glados.models.paginatedCollections.PaginatedCollectionBase.FETCHING_STATES.FILTERING_ITEMS
+      expect(stateGot).toBe(stateMustBe)

--- a/src/glados/static/coffee/tests/PaginatedCollections/ESPaginatedCollections/FetchingStateTests.coffee
+++ b/src/glados/static/coffee/tests/PaginatedCollections/ESPaginatedCollections/FetchingStateTests.coffee
@@ -67,3 +67,16 @@ describe "An elasticsearch collection", ->
       itemsStateGot = esList.getItemsFetchingState()
       itemsStateMustBe = glados.models.paginatedCollections.PaginatedCollectionBase.ITEMS_FETCHING_STATES.ITEMS_READY
       expect(itemsStateGot).toBe(itemsStateMustBe)
+
+    it 'sets the correct state after parsing items', (done) ->
+
+      simulateFacets = TestsUtils.simulateFacetsESList(esList, glados.Settings.STATIC_URL + 'testData/FacetsTestData.json', ->)
+
+      simulateFacets.then ->
+
+        facetsStateGot = esList.getFacetsFetchingState()
+        facetsStateMustBe = glados.models.paginatedCollections.PaginatedCollectionBase.FACETS_FETCHING_STATES.FACETS_READY
+        expect(facetsStateGot).toBe(facetsStateMustBe)
+
+        done()
+

--- a/src/glados/static/coffee/tests/TestsUtils.coffee
+++ b/src/glados/static/coffee/tests/TestsUtils.coffee
@@ -40,7 +40,7 @@ class TestsUtils
   # it is meant to work only for a ES compound list
   @simulateFacetsESList = (list, dataURL, done) ->
 
-    $.get dataURL, (testData) ->
+    return $.get dataURL, (testData) ->
 
       for item in testData
         aggData = item.aggData
@@ -48,7 +48,7 @@ class TestsUtils
         for facetGroupKey, facetGroup of list.getFacetsGroups()
 
           facetGroup.faceting_handler.parseESResults(aggData, firstCall)
-
+      list.setFacetsFetchingState(glados.models.paginatedCollections.PaginatedCollectionBase.FACETS_FETCHING_STATES.FACETS_READY)
       done()
 
   @generateListOfRandomValues = (minVal, maxVal) ->

--- a/src/glados/static/coffee/views/Activity/ActivityAggregationTableView.coffee
+++ b/src/glados/static/coffee/views/Activity/ActivityAggregationTableView.coffee
@@ -85,7 +85,7 @@ glados.useNameSpace 'glados.views.SearchResults',
         return
 
       numSelectedItems = @collection.getNumberOfSelectedItems()
-      threshold = glados.Settings.VIEW_SELECTION_THRESHOLDS['Bioactivity']
+      threshold = glados.Settings.VIEW_SELECTION_THRESHOLDS['Heatmap']
 
       if numSelectedItems < threshold[0]
         @setProgressMessage('Please select at least ' + threshold[0] + ' target to show this visualisation.',

--- a/src/glados/static/coffee/views/Browsers/BrowserFacetView.coffee
+++ b/src/glados/static/coffee/views/Browsers/BrowserFacetView.coffee
@@ -479,20 +479,18 @@ glados.useNameSpace 'glados.views.Browsers',
     # ------------------------------------------------------------------------------------------------------------------
     # FacetSelection
     # ------------------------------------------------------------------------------------------------------------------
-    toggleSelectFacet: (facet_group_key, facet_key) ->
+    toggleSelectFacet: (fGroupKey, fKey) ->
       @showPreloader()
       facetsGroups = @facetsVisibilityHandler.getAllFacetsGroups()
-      facetingHandler = facetsGroups[facet_group_key].faceting_handler
-      if facetingHandler.faceting_data[facet_key].count == 0
+      facetingHandler = facetsGroups[fGroupKey].faceting_handler
+      if facetingHandler.faceting_data[fKey].count == 0
         return
 
-      isSelected = facetingHandler.toggleKeySelection(facet_key)
-      $selectedSVGGroup = $(@el).find("[data-facet-group-key='" + facet_group_key + "']")\
-        .find("[data-bucket-key='" + facet_key + "']")
+      isSelected = @collection.toggleFacetAndFetch(fGroupKey, fKey)
+      $selectedSVGGroup = $(@el).find("[data-facet-group-key='" + fGroupKey + "']")\
+        .find("[data-bucket-key='" + fKey + "']")
       $selectedSVGGroup.toggleClass('selected', isSelected)
 
-      @collection.setMeta('facets_changed', true)
-      @collection.fetch()
       @WAITING_FOR_FACETS = true
 
     clearFacetsSelection: ->

--- a/src/glados/static/coffee/views/Browsers/BrowserMenuView.coffee
+++ b/src/glados/static/coffee/views/Browsers/BrowserMenuView.coffee
@@ -183,18 +183,26 @@ glados.useNameSpace 'glados.views.Browsers',
       if @collection.getTotalRecords() == 0
         return
 
-      return
-      console.log 'AAA RENDER LINK TO ALL' + (new Date())
       $selectionMenuContainer = $(@el).find('.BCK-selection-menu-container')
       $linkToAllContainer = $selectionMenuContainer.find('.BCK-LinkToAllActivitiesContainer')
 
-      if @collection.thereAreTooManyItemsForActivitiesLink()
+      tooManyItems = @collection.thereAreTooManyItemsForActivitiesLink()
+      isStreaming = @collection.isStreaming()
+      needsToBeDisabled = tooManyItems or isStreaming
+
+      if needsToBeDisabled
 
         glados.Utils.fillContentForElement $linkToAllContainer,
           too_many_items: true
 
-        qtipText = "PLease select or filter less than #{glados.Settings.VIEW_SELECTION_THRESHOLDS.Heatmap[1]} " +
-        "items to activate this link."
+
+        qtipText = switch
+          when isStreaming then \
+          "Please wait until the download is complete"
+          when tooManyItems then \
+          "Please select or filter less than #{glados.Settings.VIEW_SELECTION_THRESHOLDS.Heatmap[1]} " +
+          "items to activate this link."
+
         $linkToAllContainer.qtip
           content:
             text: qtipText
@@ -206,14 +214,18 @@ glados.useNameSpace 'glados.views.Browsers',
 
         return
 
-      glados.Utils.fillContentForElement($linkToAllContainer, paramsObj={}, customTemplate=undefined,
-        fillWithPreloader=true)
+      glados.Utils.fillContentForElement($linkToAllContainer)
 
+      $link = $linkToAllContainer.find('.BCK-LinkToAllActivities')
+      $link.click $.proxy(@handleLinkToAllActivitiesClick, @)
+      return
       linkToActPromise = @collection.getLinkToAllActivitiesPromise()
       linkToActPromise.then (linkGot) ->
         glados.Utils.fillContentForElement $linkToAllContainer,
           url: linkGot
 
+    handleLinkToAllActivitiesClick: ->
+      console.log 'handleLinkToAllActivitiesClick'
 
     #--------------------------------------------------------------------------------------
     # Download Buttons

--- a/src/glados/static/coffee/views/Browsers/BrowserMenuView.coffee
+++ b/src/glados/static/coffee/views/Browsers/BrowserMenuView.coffee
@@ -57,6 +57,7 @@ glados.useNameSpace 'glados.views.Browsers',
       if not $(@el).is(":visible")
         return
 
+      console.log 'AAA RENDER MENU VIEW' + (new Date())
       @renderMenuContent()
       if @collection.getMeta('total_records') != 0
 
@@ -164,6 +165,7 @@ glados.useNameSpace 'glados.views.Browsers',
       if @collection.getTotalRecords() == 0
         return
 
+      console.log 'AAA RENDER LINK TO ALL' + (new Date())
       $selectionMenuContainer = $(@el).find('.BCK-selection-menu-container')
       $linkToAllContainer = $selectionMenuContainer.find('.BCK-LinkToAllActivitiesContainer')
 

--- a/src/glados/static/coffee/views/Browsers/BrowserMenuView.coffee
+++ b/src/glados/static/coffee/views/Browsers/BrowserMenuView.coffee
@@ -60,14 +60,10 @@ glados.useNameSpace 'glados.views.Browsers',
       if not $(@el).is(":visible")
         return
 
-      console.log 'AAA RENDER VIEW STATE'
-      console.log 'AAA IS STREAMING: ', @collection.isStreaming()
-      console.log 'AAA  coll is ready: ', @collection.isReady()
       if not @collection.isReady() and not @collection.isStreaming()
         @showPreloader()
         return
 
-      console.log 'AAA RENDER MENU VIEW' + (new Date())
       @renderMenuContent()
       if @collection.getMeta('total_records') != 0
 
@@ -267,7 +263,6 @@ glados.useNameSpace 'glados.views.Browsers',
 
     getDisableReasonMessage: (disableReason, viewLabel) ->
 
-      console.log 'AAA GET DISABLE REASON MESSAGE: ', disableReason
       if disableReason == glados.views.Browsers.BrowserMenuView.DISABLE_BUTTON_REASONS.TOO_MANY_ITEMS
 
         threshold = 'some'

--- a/src/glados/static/coffee/views/Browsers/BrowserMenuView.coffee
+++ b/src/glados/static/coffee/views/Browsers/BrowserMenuView.coffee
@@ -17,7 +17,7 @@ glados.useNameSpace 'glados.views.Browsers',
     initialize: ->
 
       @showPreloader()
-      @collection.on 'reset do-repaint sort', @render, @
+      @collection.on 'reset do-repaint sort', @renderViewState, @
       @collection.on glados.Events.Collections.SELECTION_UPDATED, @handleSelection, @
 
       @currentViewType = @collection.getMeta('default_view')
@@ -52,7 +52,7 @@ glados.useNameSpace 'glados.views.Browsers',
       if $currentViewInstance.wakeUpView?
         $currentViewInstance.wakeUpView()
 
-    render: ->
+    renderViewState: ->
 
       if not $(@el).is(":visible")
         return
@@ -136,6 +136,9 @@ glados.useNameSpace 'glados.views.Browsers',
       return false
 
     handleSelection: ->
+
+      if not @collection.itemsAreReady()
+        return
 
       $selectionMenuContainer = $(@el).find('.BCK-selection-menu-container')
       out_of_n = @collection.getMeta('out_of_n')

--- a/src/glados/static/coffee/views/Browsers/BrowserMenuView.coffee
+++ b/src/glados/static/coffee/views/Browsers/BrowserMenuView.coffee
@@ -19,11 +19,8 @@ glados.useNameSpace 'glados.views.Browsers',
       @showPreloader()
       @collection.on 'reset do-repaint sort', @renderViewState, @
       @collection.on glados.models.paginatedCollections.PaginatedCollectionBase.EVENTS.FACETS_FETCHING_STATE_CHANGED,
-      (->
-        console.log 'AAA FETCHING STATE CHANGED'
-        console.log 'AAA' + @collection.getFacetsFetchingState()
-      ),
-      @
+      @renderViewState, @
+
       @collection.on glados.Events.Collections.SELECTION_UPDATED, @handleSelection, @
 
       @currentViewType = @collection.getMeta('default_view')
@@ -61,6 +58,13 @@ glados.useNameSpace 'glados.views.Browsers',
     renderViewState: ->
 
       if not $(@el).is(":visible")
+        return
+
+      console.log 'AAA RENDER VIEW STATE'
+      console.log 'AAA IS STREAMING: ', @collection.isStreaming()
+      console.log 'AAA  coll is ready: ', @collection.isReady()
+      if not @collection.isReady() and not @collection.isStreaming()
+        @showPreloader()
         return
 
       console.log 'AAA RENDER MENU VIEW' + (new Date())
@@ -174,6 +178,7 @@ glados.useNameSpace 'glados.views.Browsers',
       if @collection.getTotalRecords() == 0
         return
 
+      return
       console.log 'AAA RENDER LINK TO ALL' + (new Date())
       $selectionMenuContainer = $(@el).find('.BCK-selection-menu-container')
       $linkToAllContainer = $selectionMenuContainer.find('.BCK-LinkToAllActivitiesContainer')

--- a/src/glados/static/coffee/views/Browsers/BrowserMenuView.coffee
+++ b/src/glados/static/coffee/views/Browsers/BrowserMenuView.coffee
@@ -218,14 +218,20 @@ glados.useNameSpace 'glados.views.Browsers',
 
       $link = $linkToAllContainer.find('.BCK-LinkToAllActivities')
       $link.click $.proxy(@handleLinkToAllActivitiesClick, @)
-      return
-      linkToActPromise = @collection.getLinkToAllActivitiesPromise()
-      linkToActPromise.then (linkGot) ->
-        glados.Utils.fillContentForElement $linkToAllContainer,
-          url: linkGot
+
 
     handleLinkToAllActivitiesClick: ->
-      console.log 'handleLinkToAllActivitiesClick'
+
+      $selectionMenuContainer = $(@el).find('.BCK-selection-menu-container')
+      $linkToAllContainer = $selectionMenuContainer.find('.BCK-LinkToAllActivitiesContainer')
+      $preloader = $linkToAllContainer.find('.BCK-preloader')
+      $preloader.show()
+
+      linkToActPromise = @collection.getLinkToAllActivitiesPromise()
+
+      linkToActPromise.then (linkGot) ->
+        glados.Utils.URLS.shortenLinkIfTooLongAndOpen(linkGot)
+        $preloader.hide()
 
     #--------------------------------------------------------------------------------------
     # Download Buttons

--- a/src/glados/static/coffee/views/Browsers/BrowserMenuView.coffee
+++ b/src/glados/static/coffee/views/Browsers/BrowserMenuView.coffee
@@ -75,9 +75,6 @@ glados.useNameSpace 'glados.views.Browsers',
         $downloadBtnsContainer.html Handlebars.compile($('#' + $downloadBtnsContainer.attr('data-hb-template')).html())
           formats: @collection.getMeta('download_formats')
 
-        for viewLabel in @collection.getMeta('available_views')
-          console.log 'AAA VIEW MUST BE DISABLED ' + viewLabel + '--' + @checkIfViewMustBeDisabled(viewLabel)
-
         @handleSelection()
         $changeViewBtnsContainer = $(@el).find('.BCK-changeView-btns-container')
         glados.Utils.fillContentForElement $changeViewBtnsContainer,
@@ -239,19 +236,32 @@ glados.useNameSpace 'glados.views.Browsers',
 
         $currentElem = $(@)
         viewLabel = $currentElem.attr('data-view')
-        threshold = 'some'
-        if glados.Settings.VIEW_SELECTION_THRESHOLDS[viewLabel]?
-          thresholdNum = glados.Settings.VIEW_SELECTION_THRESHOLDS[viewLabel]
-          threshold = 'from ' + thresholdNum[0] + ' to ' + thresholdNum[1]
+        disableReason = $currentElem.attr('data-disabled-reason')
 
         $currentElem.qtip
           content:
-            text: 'Select ' + threshold + ' items to activate this view.'
+            text: thisView.getDisableReasonMessage(disableReason, viewLabel)
           style:
             classes:'qtip-light'
           position:
             my: 'top left'
             at: 'bottom middle'
+
+    getDisableReasonMessage: (disableReason, viewLabel) ->
+
+      console.log 'AAA GET DISABLE REASON MESSAGE: ', disableReason
+      if disableReason == glados.views.Browsers.BrowserMenuView.DISABLE_BUTTON_REASONS.TOO_MANY_ITEMS
+
+        threshold = 'some'
+        if glados.Settings.VIEW_SELECTION_THRESHOLDS[viewLabel]?
+          thresholdNum = glados.Settings.VIEW_SELECTION_THRESHOLDS[viewLabel]
+          threshold = 'from ' + thresholdNum[0] + ' to ' + thresholdNum[1]
+
+        return "Select #{threshold} items to activate this view."
+
+      if disableReason == glados.views.Browsers.BrowserMenuView.DISABLE_BUTTON_REASONS.IS_STREAMING
+
+        return "Please wait until the download is complete to activate this view."
 
     unSelectAllButtons: ->
       $(@el).find('.BCK-btn-switch-view').removeClass('selected')

--- a/src/glados/static/coffee/views/Browsers/BrowserMenuView.coffee
+++ b/src/glados/static/coffee/views/Browsers/BrowserMenuView.coffee
@@ -18,6 +18,12 @@ glados.useNameSpace 'glados.views.Browsers',
 
       @showPreloader()
       @collection.on 'reset do-repaint sort', @renderViewState, @
+      @collection.on glados.models.paginatedCollections.PaginatedCollectionBase.EVENTS.FACETS_FETCHING_STATE_CHANGED,
+      (->
+        console.log 'AAA FETCHING STATE CHANGED'
+        console.log 'AAA' + @collection.getFacetsFetchingState()
+      ),
+      @
       @collection.on glados.Events.Collections.SELECTION_UPDATED, @handleSelection, @
 
       @currentViewType = @collection.getMeta('default_view')

--- a/src/glados/static/coffee/views/Browsers/BrowserMenuView.coffee
+++ b/src/glados/static/coffee/views/Browsers/BrowserMenuView.coffee
@@ -75,13 +75,16 @@ glados.useNameSpace 'glados.views.Browsers',
         $downloadBtnsContainer.html Handlebars.compile($('#' + $downloadBtnsContainer.attr('data-hb-template')).html())
           formats: @collection.getMeta('download_formats')
 
+        for viewLabel in @collection.getMeta('available_views')
+          console.log 'AAA VIEW MUST BE DISABLED ' + viewLabel + '--' + @checkIfViewMustBeDisabled(viewLabel)
+
         @handleSelection()
         $changeViewBtnsContainer = $(@el).find('.BCK-changeView-btns-container')
         glados.Utils.fillContentForElement $changeViewBtnsContainer,
           options: ( {
             label: viewLabel,
             icon_class: glados.Settings.DEFAULT_RESULTS_VIEWS_ICONS[viewLabel]
-            is_disabled: @checkIfViewMustBeDisabled(viewLabel)
+            is_disabled: @checkIfViewMustBeDisabled(viewLabel)[0]
           } for viewLabel in @collection.getMeta('available_views'))
 
         @selectButton @currentViewType
@@ -136,14 +139,15 @@ glados.useNameSpace 'glados.views.Browsers',
     checkIfViewMustBeDisabled: (viewLabel) ->
 
       if glados.Settings.VIEW_SELECTION_THRESHOLDS[viewLabel]?
+        console.log 'AAA checking threshold'
         numSelectedItems = @collection.getNumberOfSelectedItems()
         threshold = glados.Settings.VIEW_SELECTION_THRESHOLDS[viewLabel]
         if threshold[0] <= numSelectedItems <= threshold[1]
-          return false
+          return [false]
         else
-          return true
+          return [true, glados.views.Browsers.BrowserMenuView.DISABLE_BUTTON_REASONS.TOO_MANY_ITEMS]
 
-      return false
+      return [false]
 
     handleSelection: ->
 
@@ -164,7 +168,7 @@ glados.useNameSpace 'glados.views.Browsers',
         $selectionMenuContainer.find('.tooltipped').tooltip()
 
       for viewLabel in @collection.getMeta('available_views')
-        if @checkIfViewMustBeDisabled(viewLabel)
+        if @checkIfViewMustBeDisabled(viewLabel)[0]
           @disableButton(viewLabel)
         else
           @enableButton(viewLabel)
@@ -188,7 +192,7 @@ glados.useNameSpace 'glados.views.Browsers',
         glados.Utils.fillContentForElement $linkToAllContainer,
           too_many_items: true
 
-        qtipText = "PLease select or filter less than #{glados.Settings.VIEW_SELECTION_THRESHOLDS.Bioactivity[1]} " +
+        qtipText = "PLease select or filter less than #{glados.Settings.VIEW_SELECTION_THRESHOLDS.Heatmap[1]} " +
         "items to activate this link."
         $linkToAllContainer.qtip
           content:
@@ -242,7 +246,7 @@ glados.useNameSpace 'glados.views.Browsers',
           style:
             classes:'qtip-light'
           position:
-            my: 'top right'
+            my: 'top left'
             at: 'bottom middle'
 
     unSelectAllButtons: ->
@@ -361,4 +365,5 @@ glados.useNameSpace 'glados.views.Browsers',
     toggleShowSpecialStructure: (checked) -> @getCurrentViewInstance().toggleShowSpecialStructure(checked)
 
 
-
+glados.views.Browsers.BrowserMenuView.DISABLE_BUTTON_REASONS =
+  TOO_MANY_ITEMS: 'TOO_MANY_ITEMS'

--- a/src/glados/static/coffee/views/PaginatedViews/PaginatedViewBase.coffee
+++ b/src/glados/static/coffee/views/PaginatedViews/PaginatedViewBase.coffee
@@ -11,6 +11,7 @@ glados.useNameSpace 'glados.views.PaginatedViews',
 
       @config = arguments[0].config
       @config ?= {}
+      @setInitialState()
 
       # @collection - must be provided in the constructor call
       @include_search_results_highlight = @attributes?.include_search_results_highlight || false
@@ -674,3 +675,9 @@ glados.useNameSpace 'glados.views.PaginatedViews',
       linkToActPromise.then (linkGot) ->
         console.log 'renderLinkToAllActivities: '
         console.log linkGot
+
+    # ------------------------------------------------------------------------------------------------------------------
+    # Sets the initial state
+    # ------------------------------------------------------------------------------------------------------------------
+    setInitialState: ->
+      

--- a/src/glados/static/coffee/views/PaginatedViews/PaginatedViewBase.coffee
+++ b/src/glados/static/coffee/views/PaginatedViews/PaginatedViewBase.coffee
@@ -11,7 +11,6 @@ glados.useNameSpace 'glados.views.PaginatedViews',
 
       @config = arguments[0].config
       @config ?= {}
-      @setInitialState()
 
       # @collection - must be provided in the constructor call
       @include_search_results_highlight = @attributes?.include_search_results_highlight || false
@@ -675,9 +674,3 @@ glados.useNameSpace 'glados.views.PaginatedViews',
       linkToActPromise.then (linkGot) ->
         console.log 'renderLinkToAllActivities: '
         console.log linkGot
-
-    # ------------------------------------------------------------------------------------------------------------------
-    # Sets the initial state
-    # ------------------------------------------------------------------------------------------------------------------
-    setInitialState: ->
-      

--- a/src/glados/static/coffee/views/PaginatedViews/PaginatedViewBase.coffee
+++ b/src/glados/static/coffee/views/PaginatedViews/PaginatedViewBase.coffee
@@ -666,11 +666,3 @@ glados.useNameSpace 'glados.views.PaginatedViews',
     islinkToAllActivitiesEnabled: -> @collection.getMeta('enable_activities_link_for_selected_entities') == true
 
     renderLinkToAllActivities: ->
-
-      if @collection.thereAreTooManyItemsForActivitiesLink()
-        console.log 'too many items for link!'
-        return
-      linkToActPromise = @collection.getLinkToAllActivitiesPromise()
-      linkToActPromise.then (linkGot) ->
-        console.log 'renderLinkToAllActivities: '
-        console.log linkGot

--- a/src/glados/static/coffee/views/SearchResults/ESResultsBioactivitySummaryView.coffee
+++ b/src/glados/static/coffee/views/SearchResults/ESResultsBioactivitySummaryView.coffee
@@ -71,7 +71,7 @@ glados.useNameSpace 'glados.views.SearchResults',
 
       numSelectedItems = @collection.getNumberOfSelectedItems()
       thereIsSelection = numSelectedItems > 0
-      threshold = glados.Settings.VIEW_SELECTION_THRESHOLDS['Bioactivity']
+      threshold = glados.Settings.VIEW_SELECTION_THRESHOLDS['Heatmap']
       numWorkingItems = if thereIsSelection then numSelectedItems else numTotalItems
 
       if numWorkingItems > threshold[1]

--- a/src/glados/templates/glados/Handlebars/Browsers/BrowserSources.html
+++ b/src/glados/templates/glados/Handlebars/Browsers/BrowserSources.html
@@ -94,8 +94,7 @@
     </div>
 
     <div class="BCK-LinkToAllActivitiesContainer link-to-all-activities-container"
-                                     data-hb-template="Handlebars-LinkToAllActivities"
-                                     data-hb-preloader-template="Handlebars-Common-MiniPreloader"> </div>
+                                     data-hb-template="Handlebars-LinkToAllActivities"> </div>
 
   </div>
 
@@ -103,6 +102,7 @@
 
 <script id="Handlebars-LinkToAllActivities" type="text/x-handlebars-template">
 <a target="_blank" class="BCK-LinkToAllActivities {{#if too_many_items}}disabled{{/if}}">Browse Activities</a>
+<i class="BCK-preloader fa fa-cog fa-spin fa-fw" style="display: none"></i>
 </script>
 
 <script id="Handlebars-ESResultsList" type="text/x-handlebars-template">

--- a/src/glados/templates/glados/Handlebars/Browsers/BrowserSources.html
+++ b/src/glados/templates/glados/Handlebars/Browsers/BrowserSources.html
@@ -69,7 +69,7 @@
   <div class="summary-tabs">
     {{#each options}}<a class="section-item BCK-btn-switch-view {{#if is_disabled}}disabled{{/if}}"
       data-view="{{this.label}}"
-      data-disabled-reason="{{this.disabled}}">
+      data-disabled-reason="{{this.disable_reason}}">
       <p class="icon"><i class="fa {{this.icon_class}}"></i></p>
       <p class="label">{{this.label}}</p>
     </a>{{/each}}

--- a/src/glados/templates/glados/Handlebars/Browsers/BrowserSources.html
+++ b/src/glados/templates/glados/Handlebars/Browsers/BrowserSources.html
@@ -67,7 +67,9 @@
 <script id="Handlebars-SwitchColViewButtons" type="text/x-handlebars-template">
 
   <div class="summary-tabs">
-    {{#each options}}<a class="section-item BCK-btn-switch-view {{#if is_disabled}}disabled{{/if}}" data-view="{{this.label}}">
+    {{#each options}}<a class="section-item BCK-btn-switch-view {{#if is_disabled}}disabled{{/if}}"
+      data-view="{{this.label}}"
+      data-disabled-reason="{{this.disabled}}">
       <p class="icon"><i class="fa {{this.icon_class}}"></i></p>
       <p class="label">{{this.label}}</p>
     </a>{{/each}}

--- a/src/glados/templates/glados/Handlebars/Browsers/BrowserSources.html
+++ b/src/glados/templates/glados/Handlebars/Browsers/BrowserSources.html
@@ -102,11 +102,7 @@
 </script>
 
 <script id="Handlebars-LinkToAllActivities" type="text/x-handlebars-template">
-{{#if too_many_items}}
-<a target="_blank" class="disabled">Browse Activities</a>
-{{else}}
-<a target="_blank" href="{{url}}">Browse Activities</a>
-{{/if}}
+<a target="_blank" class="BCK-LinkToAllActivities {{#if too_many_items}}disabled{{/if}}">Browse Activities</a>
 </script>
 
 <script id="Handlebars-ESResultsList" type="text/x-handlebars-template">

--- a/src/glados/templates/glados/jsTests.html
+++ b/src/glados/templates/glados/jsTests.html
@@ -44,6 +44,7 @@
   <script type="text/javascript" src="{% static 'js/coffee-gen/tests/PaginatedCollections/ESPaginatedCollections/SearchTests.js' %}"></script>
   <script type="text/javascript" src="{% static 'js/coffee-gen/tests/PaginatedCollections/ESPaginatedCollections/GeneratorListTests.js' %}"></script>
   <script type="text/javascript" src="{% static 'js/coffee-gen/tests/PaginatedCollections/ESPaginatedCollections/FacetingTests.js' %}"></script>
+  <script type="text/javascript" src="{% static 'js/coffee-gen/tests/PaginatedCollections/ESPaginatedCollections/FetchingStateTests.js' %}"></script>
   <script type="text/javascript" src="{% static 'js/coffee-gen/tests/PaginatedCollections/SelectionFunctionsTest.js' %}"></script>
   <script type="text/javascript" src="{% static 'js/coffee-gen/tests/PaginatedCollections/LinkToAllActivitiesTest.js' %}"></script>
   <script type="text/javascript" src="{% static 'js/coffee-gen/tests/DownloadsTest.js' %}"></script>


### PR DESCRIPTION
After I deployed https://github.com/chembl/GLaDOS/pull/725 I started to notice some important bugs around it. The following has been fixed:

- The collections now have a **fetching facets state** and a **fetching items state**. This states indicate what is currently going on with the items or the filters. Views that use the collection can used these states to decide what to do. For example, a view can decide to show a preloader and only show the content when **fetching facets state** is 'FACETS READY', etc. 

- When a collection is streaming, the menu shows the progress, but the 'graph' and 'heatmap' views are disabled until the download is complete. 

- The link to all activities is only activated if not too many items, and the collection is not streaming. Now it **only** calculates the link when it is clicked. This solves many bugs and makes the loading more stable. 