### PR TITLE
Do not cache visualisations page response

### DIFF
--- a/src/glados/views.py
+++ b/src/glados/views.py
@@ -15,11 +15,9 @@ import timeago
 import json
 import hashlib
 import base64
-from django.views.decorators.cache import cache_page
 from glados.models import ESCachedRequest
 
 
-@cache_page(60 * 60)
 def visualise(request):
     context = {
         'hide_breadcrumbs': True


### PR DESCRIPTION
It causes issues with the CSRF verification