### PR TITLE
Improve worker fault tolerance

### DIFF
--- a/configurations/config_example.yml
+++ b/configurations/config_example.yml
@@ -6,6 +6,7 @@ chembl_api:
   ws_url: 'https://www.ebi.ac.uk/chembl/api/data'
   beaker_url: 'https://www.ebi.ac.uk/chembl/api/utils'
 old_interface_url: 'https://www.ebi.ac.uk/chembl/old'
+current_chembl_release: 'CHEMBL25'
 server_secret_key: 'server_secret_key'
 enable_twitter: True
 twitter_secrets:

--- a/configurations/default_travis_config.yml
+++ b/configurations/default_travis_config.yml
@@ -6,4 +6,5 @@ chembl_api:
   ws_url: 'https://wwwdev.ebi.ac.uk/chembl/api/data'
   beaker_url: 'https://wwwdev.ebi.ac.uk/chembl/api/utils'
 old_interface_url: 'https://www.ebi.ac.uk/chembl/old'
+current_chembl_release: 'CHEMBL25'
 filter_query_max_clauses: 30000

--- a/configurations/default_travis_config.yml
+++ b/configurations/default_travis_config.yml
@@ -1,10 +1,10 @@
 run_env: TRAVIS
 elasticsearch:
-  host: 'https://wwwdev.ebi.ac.uk/chembl/glados-es'
-  public_host: 'https://wwwdev.ebi.ac.uk/chembl/glados-es'
+  host: 'https://www.ebi.ac.uk/chembl/glados-es'
+  public_host: 'https://www.ebi.ac.uk/chembl/glados-es'
 chembl_api:
-  ws_url: 'https://wwwdev.ebi.ac.uk/chembl/api/data'
-  beaker_url: 'https://wwwdev.ebi.ac.uk/chembl/api/utils'
+  ws_url: 'https://www.ebi.ac.uk/chembl/api/data'
+  beaker_url: 'https://www.ebi.ac.uk/chembl/api/utils'
 old_interface_url: 'https://www.ebi.ac.uk/chembl/old'
 current_chembl_release: 'CHEMBL25'
 filter_query_max_clauses: 30000

--- a/configurations/minimal_dev_config.yml
+++ b/configurations/minimal_dev_config.yml
@@ -6,4 +6,5 @@ chembl_api:
   ws_url: 'https://wwwdev.ebi.ac.uk/chembl/api/data'
   beaker_url: 'https://wwwdev.ebi.ac.uk/chembl/api/utils'
 old_interface_url: 'https://www.ebi.ac.uk/chembl/old'
+current_chembl_release: 'CHEMBL25'
 filter_query_max_clauses: 30000

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,5 @@ simplejson>=3.16.0
 redis==2.10.6
 rq==0.12.0
 django-rq==1.2.0
-pyyaml==3.13
+pyyaml==5.1
 mysqlclient==1.4.2.post1

--- a/src/glados/api/dynamic-downloads/downloads_manager.py
+++ b/src/glados/api/dynamic-downloads/downloads_manager.py
@@ -315,7 +315,7 @@ def get_download_id(index_name, raw_query, desired_format, context_id):
     if parsed_desired_format not in ['csv', 'tsv', 'sdf']:
         raise DownloadError("Format {} not supported".format(desired_format))
 
-    latest_release_full = 'chembl_24_1'
+    latest_release_full = settings.CURRENT_CHEMBL_RELEASE
     query_digest = hashlib.sha256(stable_raw_query.encode('utf-8')).digest()
     base64_query_digest = base64.b64encode(query_digest).decode('utf-8').replace('/', '_').replace('+', '-')
 

--- a/src/glados/manage.py
+++ b/src/glados/manage.py
@@ -16,6 +16,7 @@ def main():
     import glados.apache_config_generator
     import glados.admin_user_generator
     from glados.utils import manage_shortened_urls
+    from glados.utils import daemon_simulator
 
     if not os.path.exists(settings.DYNAMIC_DOWNLOADS_DIR):
         print("Dynamic downloads dir ({}) didn't exist, I will create it".format(settings.DYNAMIC_DOWNLOADS_DIR))
@@ -51,14 +52,7 @@ def main():
 
     elif os.environ.get('RUN_MAIN') != 'true' and len(sys.argv) > 1 and sys.argv[1] == 'simulatedaemon':
 
-        import datetime
-        import time
-
-        while True:
-            now = datetime.datetime.now()
-            print('working...')
-            print(now)
-            time.sleep(1)
+        daemon_simulator.work()
 
     elif os.environ.get('RUN_MAIN') != 'true' and len(sys.argv) > 1 and sys.argv[1] == 'deleteexpiredurls':
 

--- a/src/glados/manage.py
+++ b/src/glados/manage.py
@@ -17,6 +17,7 @@ def main():
     import glados.admin_user_generator
     from glados.utils import manage_shortened_urls
     from glados.utils import daemon_simulator
+    from glados.utils import rq_workers
 
     if not os.path.exists(settings.DYNAMIC_DOWNLOADS_DIR):
         print("Dynamic downloads dir ({}) didn't exist, I will create it".format(settings.DYNAMIC_DOWNLOADS_DIR))
@@ -58,8 +59,13 @@ def main():
 
         manage_shortened_urls.delete_expired_urls()
 
+    elif os.environ.get('RUN_MAIN') != 'true' and len(sys.argv) > 1 and sys.argv[1] == 'waitunitlworkersarefree':
+
+        rq_workers.wait_until_workers_are_free()
+
+    # all our custom commands are listed here so they are not sent to the original manage.py
     execute_in_manage = sys.argv[1] not in ['createapacheconfig', 'createdefaultadminuser', 'simulatedaemon',
-                                            'deleteexpiredurls']
+                                            'deleteexpiredurls', 'waitunitlworkersarefree']
     if execute_in_manage:
         execute_from_command_line(sys.argv)
 

--- a/src/glados/settings.py
+++ b/src/glados/settings.py
@@ -84,6 +84,10 @@ OLD_INTERFACE_URL = run_config.get('old_interface_url')
 if OLD_INTERFACE_URL is None:
     raise GladosSettingsError("You must provide the url for the old interface")
 
+CURRENT_CHEMBL_RELEASE = run_config.get('current_chembl_release')
+if CURRENT_CHEMBL_RELEASE is None:
+    raise GladosSettingsError("You must provide the current chembl release")
+
 # ----------------------------------------------------------------------------------------------------------------------
 # SERVER BASE PATH
 # ----------------------------------------------------------------------------------------------------------------------

--- a/src/glados/utils/daemon_simulator.py
+++ b/src/glados/utils/daemon_simulator.py
@@ -1,0 +1,10 @@
+import datetime
+import time
+
+
+def work():
+    while True:
+        now = datetime.datetime.now()
+        print('working...')
+        print(now)
+        time.sleep(1)

--- a/src/glados/utils/rq_workers.py
+++ b/src/glados/utils/rq_workers.py
@@ -1,0 +1,16 @@
+from django_rq.queues import get_queue_by_index
+from rq.worker import Worker
+
+
+def wait_until_workers_are_free():
+
+    print('Checking if there are any busy workers...')
+    # we only have one queue
+    queue_index = 0
+    queue = get_queue_by_index(queue_index)
+    all_workers = Worker.all(queue.connection)
+    print('all_workers: ', all_workers)
+    workers = [worker for worker in all_workers
+               if queue.name in worker.queue_names()]
+
+    print('workers: ', workers)


### PR DESCRIPTION
This adds a script that exits until no workers are busy. It can receive a regex to match with the workers' name. It can be called like this:

```bash
./manage_glados_no_install.sh waitunitlworkersarefree
```
Or
```bash
./manage_glados_no_install.sh waitunitlworkersarefree 'some_prefix.*'
```

This will be used in our deployment process to avoid killing and breaking running jobs.