### PR TITLE
Downloads: print in log when worker is processing a job

### DIFF
--- a/src/glados/api/chembl/dynamic_downloads/downloads_manager.py
+++ b/src/glados/api/chembl/dynamic_downloads/downloads_manager.py
@@ -234,6 +234,10 @@ def write_sdf_file(scanner, download_job):
 
 @job
 def generate_download_file(download_id):
+
+    print('-----------------------------------------------------------------------------------------------------------')
+    print('Processing job: ', download_id)
+    print('-----------------------------------------------------------------------------------------------------------')
     start_time = time.time()
     download_job = DownloadJob.objects.get(job_id=download_id)
     download_job.status = DownloadJob.PROCESSING


### PR DESCRIPTION
This just adds a print to the worker's log to help identify when it is processing a job. 