### PR TITLE
Downloads: fix bug when download exists and never expires

### DIFF
--- a/src/glados/api/chembl/dynamic_downloads/downloads_manager.py
+++ b/src/glados/api/chembl/dynamic_downloads/downloads_manager.py
@@ -468,8 +468,9 @@ def get_download_status(download_id):
         }
 
         if status == DownloadJob.FINISHED:
-            expiration_time_str = download_job.expires.replace(tzinfo=timezone.utc).isoformat()
-            response['expires'] = expiration_time_str
+            if download_job.expires is not None:
+                expiration_time_str = download_job.expires.replace(tzinfo=timezone.utc).isoformat()
+                response['expires'] = expiration_time_str
 
         return response
 

--- a/src/glados/templates/glados/Handlebars/PreloaderSources.html
+++ b/src/glados/templates/glados/Handlebars/PreloaderSources.html
@@ -75,7 +75,7 @@ You can also check the progress <a href="{{url}}" target="_blank">here</a>.
 </script>
 
 <script id="Handlebars-Common-DownloadLink" type="text/x-handlebars-template">
-Click <a href="{{url}}" target="_blank">here</a> to download your file. The download will expire on {{ expires }}.
+Click <a href="{{url}}" target="_blank">here</a> to download your file. {{#if expires }}The download will expire on {{ expires }}.  {{/if}}
 <a target="_blank" href="{% endverbatim %} {% url 'download_expiration' %}{% verbatim %}">Learn More</a>
 </script>
 


### PR DESCRIPTION
When a download never expires, it causes an error when the download is requested. This fixes this bug. It was discovered by ticket https://helpdesk.ebi.ac.uk/Ticket/Display.html?id=343488.