### PR TITLE
Remove link to old interface

### DIFF
--- a/src/glados/templates/glados/base/chembl_header.html
+++ b/src/glados/templates/glados/base/chembl_header.html
@@ -50,12 +50,6 @@
 
                     <div class="col l4 m6 s12 dropdown-item">
 
-                        <a href="{% url 'old_interface_home' %}" target="_blank">Old Interface</a>
-
-                    </div>
-
-                    <div class="col l4 m6 s12 dropdown-item">
-
                         <a href="{% url 'unichem_home' %}" target="_blank">UniChem</a>
 
                     </div>
@@ -164,8 +158,6 @@
             <li class="nav-link"><a href="{% url 'downloads' %}" target="_blank">Downloads</a></li>
 
             <li class="nav-link"><a href="{% url 'web_services_home' %}" target="_blank">Web Services</a></li>
-
-            <li class="nav-link"><a href="{% url 'old_interface_home' %}" target="_blank">Old Interface</a></li>
 
             <!-- More Links -->
             <li class="dropdown nav-link">


### PR DESCRIPTION
This removes the link to the old interface that appears in the masthead. 